### PR TITLE
Update ChiselModCompatibility.java

### DIFF
--- a/src/main/java/info/jbcs/minecraft/chisel/ChiselModCompatibility.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/ChiselModCompatibility.java
@@ -125,13 +125,13 @@ public class ChiselModCompatibility
             }
         };
 
-        new ClassBlockCompat("mariculture.core.Core", "oreBlocks")
+        new ClassBlockCompat("mariculture.core.Core", "limestone")
         {
             @Override
             void action()
             {
-                Carving.chisel.addVariation("limestone", block, 3, 99);
-                block.setHarvestLevel("chisel", 0, 3);
+                Carving.chisel.addVariation("limestone", block, 0, 99);
+                block.setHarvestLevel("chisel", 0, 0);
             }
         };
         new ClassBlockCompat("emasher.core.EmasherCore", "limestone")


### PR DESCRIPTION
Mariculture, limestone was moved to it's own block in 1.7. Fixing the compatibility.
