### PR TITLE
Goodbye .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build
 
 #runtime
 run
+
+#mac
+.DS_Store


### PR DESCRIPTION
This is so mac users like me can send pull requests without the .DS_Store file that are auto-generatored by OS-X, since most people don't those. See: http://en.wikipedia.org/wiki/.DS_Store
