### PR TITLE
Changes to the left-clicking with the Chisel in-hand...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 apply plugin: 'forge'
-version = "1.5.6b"
+version = "1.5.6c"
 group = "info.jbcs.minecraft.chisel" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Chisel"
 

--- a/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
@@ -272,6 +272,7 @@ public class Chisel
         if(!world.isRemote || chiselHasBlockInside)
         {
             world.setBlock(x, y, z, Block.getBlockFromItem(result), targetMeta, updateValue);
+            world.markBlockForUpdate(x, y, z);
         }
 
         switch(FMLCommonHandler.instance().getEffectiveSide())

--- a/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
@@ -16,6 +16,8 @@ import cpw.mods.fml.common.registry.EntityRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.Type;
 import info.jbcs.minecraft.chisel.carving.Carving;
+import info.jbcs.minecraft.chisel.carving.CarvingVariation;
+import info.jbcs.minecraft.chisel.client.GeneralChiselClient;
 import info.jbcs.minecraft.chisel.client.gui.GuiChisel;
 import info.jbcs.minecraft.chisel.entity.EntityBallOMoss;
 import info.jbcs.minecraft.chisel.entity.EntityCloudInABottle;
@@ -26,14 +28,21 @@ import info.jbcs.minecraft.chisel.item.ItemBallOMoss;
 import info.jbcs.minecraft.chisel.item.ItemChisel;
 import info.jbcs.minecraft.chisel.item.ItemCloudInABottle;
 import info.jbcs.minecraft.chisel.item.ItemSmashingRock;
+import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.world.BlockEvent;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Random;
 
 
 @Mod(modid = Chisel.MOD_ID, name = Chisel.MOD_NAME, version = "@MOD_VERSION@", guiFactory = "info.jbcs.minecraft.chisel.client.gui.GuiFactory"/*, dependencies = "after:ForgeMicroblock;"*/)
@@ -177,5 +186,137 @@ public class Chisel
         {
             Configurations.refreshConfig();
         }
+    }
+
+    HashMap<String, Long> chiselUseTime = new HashMap<String, Long>();
+    HashMap<String, String> chiselUseLocation = new HashMap<String, String>();
+    Random random = new Random();
+
+    @SubscribeEvent
+    public void onPlayerClick(PlayerInteractEvent event) {
+        if(event.action != PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) return;
+        if (!Configurations.enableChiseling) return;
+        EntityPlayer player = event.entityPlayer;
+        ItemStack stack = player.getHeldItem();
+        if (stack == null || stack.getItem() != chisel) return;
+
+        World world = event.world;
+        int x = event.x;
+        int y = event.y;
+        int z = event.z;
+
+        Block block = world.getBlock(x, y, z);
+        int blockMeta = world.getBlockMetadata(x, y, z);
+
+        ItemStack chiselTarget = null;
+
+        if(stack.stackTagCompound != null)
+        {
+            chiselTarget = ItemStack.loadItemStackFromNBT(stack.stackTagCompound.getCompoundTag("chiselTarget"));
+        }
+
+        boolean chiselHasBlockInside = true;
+
+        if(chiselTarget == null)
+        {
+            chiselHasBlockInside = false;
+
+            Long useTime = chiselUseTime.get(player.getCommandSenderName());
+            String loc = chiselUseLocation.get(player.getCommandSenderName());
+
+            if(useTime != null && chiselUseLocation != null && loc.equals(x + "|" + y + "|" + z))
+            {
+                long cooldown = 20;
+                long time = world.getWorldInfo().getWorldTotalTime();
+
+                if(time>useTime-cooldown && time<useTime+cooldown) return; //noReplace = true;
+            }
+
+            CarvingVariation[] variations = ItemChisel.carving.getVariations(block, blockMeta);
+            if(variations == null || variations.length < 2) return; //noReplace = true;
+            else
+            {
+                int index = blockMeta +1;
+                while(variations[index].block.equals(block) && variations[index].damage == blockMeta)
+                {
+                    index++;
+                    if(index >= variations.length) index = 0;
+                }
+                CarvingVariation var = variations[index];
+                chiselTarget = new ItemStack(var.block, 1, var.damage);
+            }
+        }
+        Item result = null;
+        int targetMeta = 0;
+
+        Item target = chiselTarget.getItem();
+
+        targetMeta = chiselTarget.getItemDamage();
+
+        boolean match = ItemChisel.carving.isVariationOfSameClass(Block.getBlockFromItem(target), targetMeta, block, blockMeta);
+        result = target;
+
+        /* special case: stone can be carved to cobble and bricks */
+        if(Configurations.chiselStoneToCobbleBricks)
+        {
+            if(!match && block.equals(Blocks.stone) && Block.getBlockFromItem(target).equals(ChiselBlocks.blockCobblestone))
+                match = true;
+            if(!match && block.equals(Blocks.stone) && Block.getBlockFromItem(target).equals(ChiselBlocks.stoneBrick))
+                match = true;
+        }
+        if(!match)
+            return; //noReplace = true;
+
+        int updateValue = 1;
+
+        if(!world.isRemote || chiselHasBlockInside)
+        {
+            world.setBlock(x, y, z, Block.getBlockFromItem(result), targetMeta, updateValue);
+        }
+
+        switch(FMLCommonHandler.instance().getEffectiveSide())
+        {
+            case SERVER:
+                chiselUseTime.put(player.getCommandSenderName(), world.getWorldInfo().getWorldTotalTime());
+                chiselUseLocation.put(player.getCommandSenderName(), x + "|" + y + "|" + z);
+
+                try
+                {
+                    //TODO chisel left click thingy
+                    // Packet packet = Chisel.packet.create(Packets.CHISELED).writeInt(x).writeInt(y).writeInt(z);
+                    // Chisel.packet.sendToAllAround(packet, new TargetPoint(player.dimension, x, y, z, 30.0f));
+                } catch(Exception e)
+                {
+                    e.printStackTrace();
+                }
+                break;
+
+            case CLIENT:
+                if(chiselHasBlockInside)
+                {
+                    String sound = ItemChisel.carving.getVariationSound(result, chiselTarget.getItemDamage());
+                    GeneralChiselClient.spawnChiselEffect(x, y, z, sound);
+                }
+                break;
+
+            default:
+                break;
+        }
+
+        stack.damageItem(1, player);
+        if(stack.stackSize == 0)
+        {
+            player.inventory.mainInventory[player.inventory.currentItem] = chiselHasBlockInside ? chiselTarget : null;
+        }
+    }
+
+    @SubscribeEvent
+    public void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (!Configurations.enableChiseling) return;
+        EntityPlayer player = event.getPlayer();
+        ItemStack stack = player.getHeldItem();
+        if (stack == null || stack.getItem() != chisel) return;
+
+        event.setCanceled(true);
     }
 }

--- a/src/main/java/info/jbcs/minecraft/chisel/ChiselModCompatibility.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/ChiselModCompatibility.java
@@ -20,7 +20,7 @@ public class ChiselModCompatibility
                     action();
             } catch(ClassNotFoundException e)
             {
-                e.printStackTrace();
+                //e.printStackTrace();
             } catch(IllegalArgumentException e)
             {
                 e.printStackTrace();

--- a/src/main/java/info/jbcs/minecraft/chisel/item/ItemChisel.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/item/ItemChisel.java
@@ -9,6 +9,7 @@ import info.jbcs.minecraft.chisel.carving.Carving;
 import info.jbcs.minecraft.chisel.carving.CarvingVariation;
 import info.jbcs.minecraft.chisel.client.GeneralChiselClient;
 import net.minecraft.block.Block;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -24,9 +25,7 @@ import java.util.Set;
 
 public class ItemChisel extends ItemTool
 {
-    Random random = new Random();
-    public Carving carving;
-
+    public static Carving carving = Carving.chisel;
     private static final HashSet<String> toolSet = new HashSet<String>();
 
     public ItemChisel(Carving c)
@@ -39,7 +38,7 @@ public class ItemChisel extends ItemTool
         setUnlocalizedName("chisel");
 
         toolSet.add("chisel");
-        this.carving = c;
+        //this.carving = c;
     }
 
     @Override
@@ -56,135 +55,8 @@ public class ItemChisel extends ItemTool
         return itemstack;
     }
 
-    HashMap<String, Long> chiselUseTime = new HashMap<String, Long>();
-    HashMap<String, String> chiselUseLocation = new HashMap<String, String>();
-
     @Override
-    public boolean onBlockStartBreak(ItemStack stack, final int x, final int y, final int z, EntityPlayer player)
-    {
-        if(!Configurations.enableChiseling) return true;
-
-        World world = player.worldObj;
-        Block block = world.getBlock(x, y, z);
-        int blockMeta = world.getBlockMetadata(x, y, z);
-
-        if(!ForgeHooks.isToolEffective(stack, block, blockMeta))
-            return false;
-
-        ItemStack chiselTarget = null;
-
-        if(stack.stackTagCompound != null)
-        {
-            chiselTarget = ItemStack.loadItemStackFromNBT(stack.stackTagCompound.getCompoundTag("chiselTarget"));
-        }
-
-        boolean chiselHasBlockInside = true;
-
-        boolean noReplace = false;
-
-        if(chiselTarget == null)
-        {
-            chiselHasBlockInside = false;
-
-            Long useTime = chiselUseTime.get(player.getCommandSenderName());
-            String loc = chiselUseLocation.get(player.getCommandSenderName());
-
-            if(useTime != null && chiselUseLocation != null && loc.equals(x + "|" + y + "|" + z))
-            {
-                long cooldown = 20;
-                long time = world.getWorldInfo().getWorldTotalTime();
-
-                if(time>useTime-cooldown && time<useTime+cooldown) noReplace = true;
-            }
-
-            CarvingVariation[] variations = carving.getVariations(block, blockMeta);
-            if(variations == null || variations.length < 2) noReplace = true;
-            else
-            {
-                int index = random.nextInt(variations.length - 1);
-                while(variations[index].block.equals(block) && variations[index].damage == blockMeta)
-                {
-                    index++;
-                    if(index >= variations.length) index = 0;
-                }
-                CarvingVariation var = variations[index];
-                chiselTarget = new ItemStack(var.block, 1, var.damage);
-            }
-        }
-        Item result = null;
-        int targetMeta = 0;
-
-        if(!noReplace)
-        {
-            Item target = chiselTarget.getItem();
-
-            targetMeta = chiselTarget.getItemDamage();
-
-            boolean match = carving.isVariationOfSameClass(Block.getBlockFromItem(target), targetMeta, block, blockMeta);
-            result = target;
-
-			/* special case: stone can be carved to cobble and bricks */
-            if(Configurations.chiselStoneToCobbleBricks)
-            {
-                if(!match && block.equals(Blocks.stone) && Block.getBlockFromItem(target).equals(ChiselBlocks.blockCobblestone))
-                    match = true;
-                if(!match && block.equals(Blocks.stone) && Block.getBlockFromItem(target).equals(ChiselBlocks.stoneBrick))
-                    match = true;
-            }
-            if(!match)
-                noReplace = true;
-        }
-
-        int updateValue = 2;
-
-        if(noReplace)
-        {
-            result = Item.getItemFromBlock(block);
-            targetMeta = blockMeta;
-        }
-
-        if(!world.isRemote || chiselHasBlockInside)
-        {
-            world.setBlock(x, y, z, Block.getBlockFromItem(result), targetMeta, updateValue);
-        }
-
-        switch(FMLCommonHandler.instance().getEffectiveSide())
-        {
-            case SERVER:
-                chiselUseTime.put(player.getCommandSenderName(), world.getWorldInfo().getWorldTotalTime());
-                chiselUseLocation.put(player.getCommandSenderName(), x + "|" + y + "|" + z);
-
-                try
-                {
-                    //TODO chisel left click thingy
-                    // Packet packet = Chisel.packet.create(Packets.CHISELED).writeInt(x).writeInt(y).writeInt(z);
-                    // Chisel.packet.sendToAllAround(packet, new TargetPoint(player.dimension, x, y, z, 30.0f));
-                } catch(Exception e)
-                {
-                    e.printStackTrace();
-                }
-                break;
-
-            case CLIENT:
-                if(chiselHasBlockInside)
-                {
-                    String sound = carving.getVariationSound(result, chiselTarget.getItemDamage());
-                    GeneralChiselClient.spawnChiselEffect(x, y, z, sound);
-                }
-                break;
-
-            default:
-                break;
-        }
-
-        stack.damageItem(1, player);
-        if(stack.stackSize == 0)
-        {
-            player.inventory.mainInventory[player.inventory.currentItem] = chiselHasBlockInside ? chiselTarget : null;
-        }
-
+    public boolean onBlockStartBreak(ItemStack itemstack, int X, int Y, int Z, EntityPlayer player) {
         return true;
     }
-
-
 }


### PR DESCRIPTION
Basicly, the Chisel as item can't break ANY blocks anymore, it's all handled through Forge-events.
I don't think there are needs to check, if the config-option for this is enabled / disabled, so the item can still break blocks in the world... Seems useless..
