### PR TITLE
Unify block names

### DIFF
--- a/src/main/java/info/jbcs/minecraft/chisel/BlockNameConversion.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/BlockNameConversion.java
@@ -1,0 +1,105 @@
+package info.jbcs.minecraft.chisel;
+
+import info.jbcs.minecraft.utilities.General;
+
+import java.util.HashMap;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+
+public class BlockNameConversion
+{
+    static final private HashMap<String, String> namingConversion = new HashMap<String, String>();
+
+    public static class NameConversions
+    {
+        public final static int MAX = 5;
+
+        protected static String conversion(String oldname, int step)
+        {
+            oldname = General.cleanTags(oldname);
+            String newname = null;
+            switch (step) {
+                case 0: // lookup list
+                    return namingConversion.get(oldname);
+                case 1: // simple lower case
+                    return oldname.toLowerCase();
+                case 2: // rename "marbleSlab" -> "marble_slab", "blockRedstone" -> "redstone_block"
+                    newname = oldname.replaceAll("([a-z]+)([A-Z])", "$1_$2").toLowerCase();
+                    if (newname.startsWith("block_"))
+                    {
+                        newname = newname.replaceFirst("block_([a-z_]+)", "$1_block");
+                    }
+                    else if (newname.startsWith("snakestone_"))
+                    {
+                        newname = newname.replaceFirst("snakestone_([a-z_]+)", "$1_snakestone");
+                    }
+                    return newname;
+                case 3: // rename "wood-dark-oak" -> "dark_oak_planks"
+                    newname = oldname.replaceAll("([a-z]+)([A-Z])", "$1_$2").toLowerCase().replace('-', '_');
+                    if (newname.contains("wood_"))
+                    {
+                        newname = newname.replaceFirst("wood_([a-z_]+)", "$1_planks");
+                    }
+                    return newname;
+                case (MAX - 1): // ALWAYS last: rename "blockYxx" -> "yxx" (e.g. "blockDirt" -> "dirt").
+                                // This can be dangerous in cases like "blockCarpet" (a block) -> "carpet" (NO block)
+                    return oldname.replaceAll("([a-z]+)([A-Z])", "$1_$2").toLowerCase().replaceFirst("block_", "");
+                default:
+                    throw new IndexOutOfBoundsException("conversion got invalid parameter step=" + step);
+            }
+        }
+    }
+
+    static public void init()
+    {
+        namingConversion.put("blockCobble", "cobblestone");
+        namingConversion.put("iron", "iron_block");
+        namingConversion.put("gold", "gold_block");
+        namingConversion.put("diamond", "diamond_block");
+        namingConversion.put("lightstone", "glowstone");
+        namingConversion.put("lapis", "lapis_block");
+        namingConversion.put("emerald", "emerald_block");
+        namingConversion.put("hellrock", "netherrack");
+        namingConversion.put("stoneMoss", "mossy_cobblestone");
+        namingConversion.put("stoneBrick", "stonebrick");
+        namingConversion.put("fenceIron", "iron_bars");
+        namingConversion.put("blockFft", "fantasyblock");
+        namingConversion.put("blockCarpetFloor", "carpet");
+        namingConversion.put("blockTemple", "templeblock");
+        namingConversion.put("blockTempleMossy", "mossy_templeblock");
+        namingConversion.put("blockFactory", "factoryblock");
+        namingConversion.put("blockLaboratory", "laboratoryblock");
+        // "LightGray" is unfortunately converted to "light_gray"
+        namingConversion.put("stainedGlassLightGray", "stained_glass_lightgray");
+        namingConversion.put("stainedGlassPaneLightGray", "stained_glass_pane_lightgray");
+    }
+
+    public static Item findItem(String oldname)
+    {
+        FMLLog.getLogger().trace("findItem() START " + oldname);
+        Item item = null;
+        for (int i = 0; i < NameConversions.MAX && item == null; i++)
+        {
+            FMLLog.getLogger().trace("findItem()       Checking for " + NameConversions.conversion(oldname, i));
+            item = GameRegistry.findItem(Chisel.MOD_ID, NameConversions.conversion(oldname, i));
+        }
+
+        return item;
+    }
+
+    public static Block findBlock(String oldname)
+    {
+        FMLLog.getLogger().trace("findBlock() START: " + oldname);
+        Block block = null;
+        for (int i = 0; i < NameConversions.MAX && block == null; i++)
+        {
+            FMLLog.getLogger().trace("findBlock()       Checking for " + NameConversions.conversion(oldname, i));
+            block = GameRegistry.findBlock(Chisel.MOD_ID, NameConversions.conversion(oldname, i));
+        }
+
+        return block;
+    }
+}

--- a/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
@@ -74,6 +74,8 @@ public class Chisel
     @EventHandler
     public void missingMapping(FMLMissingMappingsEvent event)
     {
+        BlockNameConversion.init();
+
         for(MissingMapping m : event.get())
         {
             // This bug was introduced along with Chisel 1.5.2, and was fixed in 1.5.3.
@@ -87,8 +89,7 @@ public class Chisel
             // Fix mapping of snakestoneSand, snakestoneStone, limestoneStairs, marbleStairs when loading an old (1.5.4) save
             else if(m.type == Type.BLOCK)
             {
-                Block block = null;
-                block = GameRegistry.findBlock(Chisel.MOD_ID, General.cleanTags(m.name));
+                final Block block = BlockNameConversion.findBlock(m.name);
 
                 if(block != null)
                 {
@@ -98,8 +99,7 @@ public class Chisel
                     FMLLog.getLogger().warn("Block " + m.name + " could not get remapped.");
             } else if(m.type == Type.ITEM)
             {
-                Item item = null;
-                item = GameRegistry.findItem(Chisel.MOD_ID, General.cleanTags(m.name));
+                final Item item = BlockNameConversion.findItem(m.name);
 
                 if(item != null)
                 {

--- a/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/Chisel.java
@@ -88,13 +88,7 @@ public class Chisel
             else if(m.type == Type.BLOCK)
             {
                 Block block = null;
-
-                if(General.cleanTags(m.name).equals("sandSnakestone"))
-                    block = GameRegistry.findBlock(Chisel.MOD_ID, "tile.snakestoneSand");
-                else if(General.cleanTags(m.name).equals("snakestone"))
-                    block = GameRegistry.findBlock(Chisel.MOD_ID, "tile.snakestoneStone");
-                else
-                    block = GameRegistry.findBlock(Chisel.MOD_ID, General.cleanTags(m.name));
+                block = GameRegistry.findBlock(Chisel.MOD_ID, General.cleanTags(m.name));
 
                 if(block != null)
                 {
@@ -105,13 +99,7 @@ public class Chisel
             } else if(m.type == Type.ITEM)
             {
                 Item item = null;
-
-                if(General.cleanTags(m.name).equals("sandSnakestone"))
-                    item = GameRegistry.findItem(Chisel.MOD_ID, "tile.snakestoneSand");
-                else if(General.cleanTags(m.name).equals("snakestone"))
-                    item = GameRegistry.findItem(Chisel.MOD_ID, "tile.snakestoneStone");
-                else
-                    item = GameRegistry.findItem(Chisel.MOD_ID, General.cleanTags(m.name));
+                item = GameRegistry.findItem(Chisel.MOD_ID, General.cleanTags(m.name));
 
                 if(item != null)
                 {
@@ -149,7 +137,7 @@ public class Chisel
         {
             itemCloudInABottle = (ItemCloudInABottle) new ItemCloudInABottle().setTextureName("Chisel:cloudinabottle").setCreativeTab(CreativeTabs.tabTools);
             EntityRegistry.registerModEntity(EntityCloudInABottle.class, "CloudInABottle", 1, this, 40, 1, true);
-            GameRegistry.registerItem(itemCloudInABottle, "chisel.cloudinabottle");
+            GameRegistry.registerItem(itemCloudInABottle, "cloudinabottle");
         }
 
         if(Configurations.featureEnabled("ballOfMoss"))

--- a/src/main/java/info/jbcs/minecraft/chisel/ChiselBlocks.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/ChiselBlocks.java
@@ -372,7 +372,7 @@ public class ChiselBlocks
             if(Configurations.featureEnabled("snakeSandstone"))
             {
                 blockSandSnakestone = (BlockSnakestone) new BlockSnakestone("Chisel:snakestone/sandsnake/").setBlockName("snakestoneSand");
-                GameRegistry.registerBlock(blockSandSnakestone, ItemCarvable.class, blockSandSnakestone.getUnlocalizedName());
+                GameRegistry.registerBlock(blockSandSnakestone, ItemCarvable.class, "snakestoneSand");
                 //TODO- eat me!
                 //LanguageRegistry.addName(new ItemStack(blockSandSnakestone, 1, 1), "Sandstone snake block head");
                 //LanguageRegistry.addName(new ItemStack(blockSandSnakestone, 1, 13), "Sandstone snake block body");
@@ -653,7 +653,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("snakestone"))
         {
             blockSnakestone = (BlockSnakestone) new BlockSnakestone("Chisel:snakestone/snake/").setBlockName("snakestoneStone");
-            GameRegistry.registerBlock(blockSnakestone, ItemCarvable.class, blockSnakestone.getUnlocalizedName());
+            GameRegistry.registerBlock(blockSnakestone, ItemCarvable.class, "snakestoneStone");
             //LanguageRegistry.addName(new ItemStack(blockSnakestone, 1, 1), "Stone snake block head");
             //LanguageRegistry.addName(new ItemStack(blockSnakestone, 1, 13), "Stone snake block body");
             Carving.chisel.addVariation("stoneBrick", blockSnakestone, 1, 16);
@@ -758,7 +758,7 @@ public class ChiselBlocks
                     {
                         return new BlockMarbleIceStairs(block, meta, helper);
                     }
-                }, "chisel.iceStairs");
+                }, "iceStairs");
             }
         }
 
@@ -826,7 +826,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("snakestoneObsidian"))
         {
             blockObsidianSnakestone = (BlockSnakestoneObsidian) new BlockSnakestoneObsidian("Chisel:snakestone/obsidian/").setBlockName("obsidianSnakestone").setHardness(50.0F).setResistance(2000.0F);
-            GameRegistry.registerBlock(blockObsidianSnakestone, ItemCarvable.class, blockObsidianSnakestone.getUnlocalizedName());
+            GameRegistry.registerBlock(blockObsidianSnakestone, ItemCarvable.class, "obsidianSnakestone");
             //LanguageRegistry.addName(new ItemStack(blockObsidianSnakestone, 1, 1), "Obsidian snakestone head");
             //LanguageRegistry.addName(new ItemStack(blockObsidianSnakestone, 1, 13), "Obsidian snakestone body");
             Carving.chisel.addVariation("obsidian", blockObsidianSnakestone, 1, 16);
@@ -1140,7 +1140,7 @@ public class ChiselBlocks
 
         if(Configurations.featureEnabled("glassStained")) for(int i = 0; i < 16; i++)
         {
-            String blockName = "chisel.stainedGlass" + sGNames[i].replaceAll(" ", "");
+            final String blockName = "stainedGlass" + sGNames[i].replaceAll(" ", "");
             String oreName = "stainedGlass" + sGNames[i].replaceAll(" ", "");
             String texName = "glassdyed/" + sGNames[i].toLowerCase().replaceAll(" ", "") + "-";
             int glassPrefix = (i & 3) << 2;
@@ -1168,7 +1168,7 @@ public class ChiselBlocks
 
         if(Configurations.featureEnabled("glassStainedPane")) for(int i = 0; i < 16; i++)
         {
-            String blockName = "chisel.stainedGlassPane" + sGNames[i].replaceAll(" ", "");
+            final String blockName = "stainedGlassPane" + sGNames[i].replaceAll(" ", "");
             String oreName = "stainedGlassPane" + sGNames[i].replaceAll(" ", "");
             String texName = "glasspanedyed/" + sGNames[i].toLowerCase().replaceAll(" ", "") + "-";
             Carving.chisel.addVariation(blockName, Blocks.stained_glass_pane, i, 0);
@@ -1251,5 +1251,4 @@ public class ChiselBlocks
 
         Blocks.stone.setHarvestLevel("chisel", 0, 0);
     }
-
 }

--- a/src/main/java/info/jbcs/minecraft/chisel/ChiselBlocks.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/ChiselBlocks.java
@@ -125,7 +125,7 @@ public class ChiselBlocks
             blockMarbleSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleSlab.13.desc"), 13, "marbleslab/marble-arranged-bricks");
             blockMarbleSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleSlab.14.desc"), 14, "marbleslab/marble-fancy-bricks");
             blockMarbleSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleSlab.15.desc"), 15, "marbleslab/marble-blocks");
-            blockMarbleSlab.carverHelper.register(blockMarbleSlab, "marbleSlab", ItemMarbleSlab.class);
+            blockMarbleSlab.carverHelper.register(blockMarbleSlab, "marble_slab", ItemMarbleSlab.class);
 
             if(Configurations.featureEnabled("marblePillar"))
             {
@@ -170,8 +170,8 @@ public class ChiselBlocks
                     blockMarblePillar.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marblePillar.14.desc"), 14, "marblepillar/carved");
                     blockMarblePillar.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marblePillar.15.desc"), 15, "marblepillar/ornamental");
                 }
-                blockMarblePillar.carverHelper.register(blockMarblePillar, "marblePillar");
-                Carving.chisel.setGroupClass("marblePillar", "marble");
+                blockMarblePillar.carverHelper.register(blockMarblePillar, "marble_pillar");
+                Carving.chisel.setGroupClass("marble_pillar", "marble");
 
                 blockMarblePillarSlab = (BlockMarbleSlab) new BlockMarbleSlab(blockMarblePillar).setHardness(2.0F).setResistance(10F).setStepSound(Block.soundTypeStone);
                 blockMarblePillarSlab.carverHelper.setChiselBlockName("Marble Pillar Slab");
@@ -212,7 +212,7 @@ public class ChiselBlocks
                     blockMarblePillarSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marblePillarSlab.14.desc"), 14, "marblepillarslab/carved");
                     blockMarblePillarSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marblePillarSlab.15.desc"), 15, "marblepillarslab/ornamental");
                 }
-                blockMarblePillarSlab.carverHelper.register(blockMarblePillarSlab, "marblePillarSlab", ItemMarbleSlab.class);
+                blockMarblePillarSlab.carverHelper.register(blockMarblePillarSlab, "marble_pillar_slab", ItemMarbleSlab.class);
             }
 
             BlockMarbleStairsMaker makerMarbleStairs = new BlockMarbleStairsMaker(blockMarble);
@@ -233,7 +233,7 @@ public class ChiselBlocks
             makerMarbleStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleStairs.13.desc"), 13, "marbleslab/marble-arranged-bricks");
             makerMarbleStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleStairs.14.desc"), 14, "marbleslab/marble-fancy-bricks");
             makerMarbleStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.marbleStairs.15.desc"), 15, "marbleslab/marble-blocks");
-            makerMarbleStairs.create("marbleStairs");
+            makerMarbleStairs.create("marble_stairs");
         }
 
         if(Configurations.featureEnabled("limestone"))
@@ -278,7 +278,7 @@ public class ChiselBlocks
             blockLimestoneSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneSlab.13.desc"), 13, "limestone/terrain-pistonback-lightfour");
             blockLimestoneSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneSlab.14.desc"), 14, "limestone/terrain-pistonback-lightmarker");
             blockLimestoneSlab.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneSlab.15.desc"), 15, "limestone/terrain-pistonback-lightpanel");
-            blockLimestoneSlab.carverHelper.register(blockLimestoneSlab, "limestoneSlab", ItemMarbleSlab.class);
+            blockLimestoneSlab.carverHelper.register(blockLimestoneSlab, "limestone_slab", ItemMarbleSlab.class);
 
             BlockMarbleStairsMaker makerLimestoneStairs = new BlockMarbleStairsMaker(blockLimestone);
             makerLimestoneStairs.carverHelper.setChiselBlockName("Limestone Stairs");
@@ -298,7 +298,7 @@ public class ChiselBlocks
             makerLimestoneStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneStairs.13.desc"), 13, "limestone/terrain-pistonback-lightfour");
             makerLimestoneStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneStairs.14.desc"), 14, "limestone/terrain-pistonback-lightmarker");
             makerLimestoneStairs.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.limestoneStairs.15.desc"), 15, "limestone/terrain-pistonback-lightpanel");
-            makerLimestoneStairs.create("limestoneStairs");
+            makerLimestoneStairs.create("limestone_stairs");
         }
 
         if(Configurations.featureEnabled("cobblestone"))
@@ -321,7 +321,7 @@ public class ChiselBlocks
             blockCobblestone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.cobblestone.13.desc"), 14, "cobblestone/terrain-pistonback-darkmarker");
             blockCobblestone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.cobblestone.14.desc"), 15, "cobblestone/terrain-pistonback-darkpanel");
             blockCobblestone.carverHelper.register(blockCobblestone, "cobblestone");
-            Carving.chisel.registerOre("cobblestone", "blockCobble");
+            Carving.chisel.registerOre("cobblestone", "cobblestone");
         }
 
         if(Configurations.featureEnabled("glass"))
@@ -372,7 +372,7 @@ public class ChiselBlocks
             if(Configurations.featureEnabled("snakeSandstone"))
             {
                 blockSandSnakestone = (BlockSnakestone) new BlockSnakestone("Chisel:snakestone/sandsnake/").setBlockName("snakestoneSand");
-                GameRegistry.registerBlock(blockSandSnakestone, ItemCarvable.class, "snakestoneSand");
+                GameRegistry.registerBlock(blockSandSnakestone, ItemCarvable.class, "sand_snakestone");
                 //TODO- eat me!
                 //LanguageRegistry.addName(new ItemStack(blockSandSnakestone, 1, 1), "Sandstone snake block head");
                 //LanguageRegistry.addName(new ItemStack(blockSandSnakestone, 1, 13), "Sandstone snake block body");
@@ -400,7 +400,7 @@ public class ChiselBlocks
             blockSandstoneScribbles.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.sandstoneScribbles.desc"), 13, "sandstone-scribbles/scribbles-13");
             blockSandstoneScribbles.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.sandstoneScribbles.desc"), 14, "sandstone-scribbles/scribbles-14");
             blockSandstoneScribbles.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.sandstoneScribbles.desc"), 15, "sandstone-scribbles/scribbles-15");
-            blockSandstoneScribbles.carverHelper.register(blockSandstoneScribbles, "sandstoneScribbles");
+            blockSandstoneScribbles.carverHelper.register(blockSandstoneScribbles, "sandstone_scribbles");
         }
 
         if(Configurations.featureEnabled("concrete"))
@@ -425,7 +425,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("roadLine"))
         {
             blockRoadLine = (BlockRoadLine) new BlockRoadLine().setStepSound(Block.soundTypeStone).setHardness(0.01F).setBlockName("roadLine");
-            GameRegistry.registerBlock(blockRoadLine, ItemCarvable.class, "roadLine");
+            GameRegistry.registerBlock(blockRoadLine, ItemCarvable.class, "road_line");
             //TODO- flag
             //LanguageRegistry.addName(new ItemStack(blockRoadLine, 1, 0), "Road lines");
         }
@@ -433,7 +433,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("ironBlock"))
         {
             blockIron = (BlockBeaconBase) new BlockBeaconBase().setHardness(5F).setResistance(10F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("iron", Blocks.iron_block, 0, 0);
+            Carving.chisel.addVariation("iron_block", Blocks.iron_block, 0, 0);
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.1.desc"), 1, "iron/terrain-iron-largeingot");
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.2.desc"), 2, "iron/terrain-iron-smallingot");
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.3.desc"), 3, "iron/terrain-iron-gears");
@@ -449,14 +449,14 @@ public class ChiselBlocks
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.13.desc"), 13, "iron/terrain-iron-spaceblack");
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.14.desc"), 14, "iron/terrain-iron-vents");
             blockIron.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.iron.15.desc"), 15, "iron/terrain-iron-simple");
-            blockIron.carverHelper.register(blockIron, "iron");
-            Carving.chisel.registerOre("iron", "blockIron");
+            blockIron.carverHelper.register(blockIron, "iron_block");
+            Carving.chisel.registerOre("iron_block", "blockIron");
         }
 
         if(Configurations.featureEnabled("goldBlock"))
         {
             blockGold = (BlockBeaconBase) new BlockBeaconBase().setHardness(3F).setResistance(10F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("gold", Blocks.gold_block, 0, 0);
+            Carving.chisel.addVariation("gold_block", Blocks.gold_block, 0, 0);
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.1.desc"), 1, "gold/terrain-gold-largeingot");
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.2.desc"), 2, "gold/terrain-gold-smallingot");
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.3.desc"), 3, "gold/terrain-gold-brick");
@@ -471,14 +471,14 @@ public class ChiselBlocks
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.12.desc"), 12, "gold/terrain-gold-space");
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.13.desc"), 13, "gold/terrain-gold-spaceblack");
             blockGold.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.gold.14.desc"), 14, "gold/terrain-gold-simple");
-            blockGold.carverHelper.register(blockGold, "gold");
-            Carving.chisel.registerOre("gold", "blockGold");
+            blockGold.carverHelper.register(blockGold, "gold_block");
+            Carving.chisel.registerOre("gold_block", "blockGold");
         }
 
         if(Configurations.featureEnabled("diamondBlock"))
         {
             blockDiamond = (BlockBeaconBase) new BlockBeaconBase().setHardness(5F).setResistance(10F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("diamond", Blocks.diamond_block, 0, 0);
+            Carving.chisel.addVariation("diamond_block", Blocks.diamond_block, 0, 0);
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.1.desc"), 1, "diamond/terrain-diamond-embossed");
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.2.desc"), 2, "diamond/terrain-diamond-gem");
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.3.desc"), 3, "diamond/terrain-diamond-cells");
@@ -491,14 +491,14 @@ public class ChiselBlocks
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.10.desc"), 10, "diamond/a1-blockdiamond-fourornate");
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.11.desc"), 11, "diamond/a1-blockdiamond-zelda");
             blockDiamond.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.diamond.12.desc"), 12, "diamond/a1-blockdiamond-ornatelayer");
-            blockDiamond.carverHelper.register(blockDiamond, "diamond");
-            Carving.chisel.registerOre("diamond", "blockDiamond");
+            blockDiamond.carverHelper.register(blockDiamond, "diamond_block");
+            Carving.chisel.registerOre("diamond_block", "blockDiamond");
         }
 
         if(Configurations.featureEnabled("glowstone"))
         {
             blockLightstone = (BlockLightstoneCarvable) new BlockLightstoneCarvable().setHardness(0.3F).setLightLevel(1.0F).setStepSound(Block.soundTypeGlass);
-            Carving.chisel.addVariation("lightstone", Blocks.glowstone, 0, 0);
+            Carving.chisel.addVariation("glowstone", Blocks.glowstone, 0, 0);
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.1.desc"), 1, "lightstone/terrain-sulphur-cobble");
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.2.desc"), 2, "lightstone/terrain-sulphur-corroded");
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.3.desc"), 3, "lightstone/terrain-sulphur-glass");
@@ -514,14 +514,14 @@ public class ChiselBlocks
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.13.desc"), 13, "lightstone/a1-glowstone-tilecorroded");
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.14.desc"), 14, "lightstone/glowstone-bismuth");
             blockLightstone.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lightstone.15.desc"), 15, "lightstone/glowstone-bismuth-panel");
-            blockLightstone.carverHelper.register(blockLightstone, "lightstone");
-            Carving.chisel.registerOre("lightstone", "blockGlowstone");
+            blockLightstone.carverHelper.register(blockLightstone, "glowstone");
+            Carving.chisel.registerOre("glowstone", "glowstone");
         }
 
         if(Configurations.featureEnabled("lapisBlock"))
         {
             blockLapis = (BlockCarvable) new BlockCarvable().setHardness(3F).setResistance(5F).setStepSound(Block.soundTypeStone);
-            Carving.chisel.addVariation("lapis", Blocks.lapis_block, 0, 0);
+            Carving.chisel.addVariation("lapis_block", Blocks.lapis_block, 0, 0);
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.1.desc"), 1, "lapis/terrain-lapisblock-chunky");
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.2.desc"), 2, "lapis/terrain-lapisblock-panel");
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.3.desc"), 3, "lapis/terrain-lapisblock-zelda");
@@ -530,14 +530,14 @@ public class ChiselBlocks
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.6.desc"), 6, "lapis/a1-blocklapis-panel");
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.7.desc"), 7, "lapis/a1-blocklapis-smooth");
             blockLapis.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.lapis.8.desc"), 8, "lapis/a1-blocklapis-ornatelayer");
-            blockLapis.carverHelper.register(blockLapis, "lapis");
-            Carving.chisel.registerOre("lapis", "blockLapis");
+            blockLapis.carverHelper.register(blockLapis, "lapis_block");
+            Carving.chisel.registerOre("lapis_block", "blockLapis");
         }
 
         if(Configurations.featureEnabled("emeraldBlock"))
         {
             blockEmerald = (BlockBeaconBase) new BlockBeaconBase().setHardness(5.0F).setResistance(10.0F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("emerald", Blocks.emerald_block, 0, 0);
+            Carving.chisel.addVariation("emerald_block", Blocks.emerald_block, 0, 0);
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.1.desc"), 1, "emerald/a1-blockemerald-emeraldpanel");
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.2.desc"), 2, "emerald/a1-blockemerald-emeraldpanelclassic");
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.3.desc"), 3, "emerald/a1-blockemerald-emeraldsmooth");
@@ -549,14 +549,14 @@ public class ChiselBlocks
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.9.desc"), 9, "emerald/a1-blockquartz-four");
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.10.desc"), 10, "emerald/a1-blockquartz-fourornate");
             blockEmerald.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.emerald.11.desc"), 11, "emerald/a1-blockquartz-ornate");
-            blockEmerald.carverHelper.register(blockEmerald, "emerald");
-            Carving.chisel.registerOre("emerald", "blockEmerald");
+            blockEmerald.carverHelper.register(blockEmerald, "emerald_block");
+            Carving.chisel.registerOre("emerald_block", "blockEmerald");
         }
 
         if(Configurations.featureEnabled("netherBrick"))
         {
             blockNetherBrick = (BlockCarvable) new BlockCarvable().setHardness(2.0F).setResistance(10.0F).setStepSound(Block.soundTypeStone);
-            Carving.chisel.addVariation("netherBrick", Blocks.nether_brick, 0, 0);
+            Carving.chisel.addVariation("nether_brick", Blocks.nether_brick, 0, 0);
             //blockNetherBrick.carverHelper.addVariation("Nether brick", 0, Blocks.nether_brick);
             blockNetherBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.netherBrick.1.desc"), 1, "netherbrick/a1-netherbrick-brinstar");
             blockNetherBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.netherBrick.2.desc"), 2, "netherbrick/a1-netherbrick-classicspatter");
@@ -573,14 +573,14 @@ public class ChiselBlocks
             blockNetherBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.netherBrick.13.desc"), 13, "netherbrick/a1-netherbrick-meatsmall");
             blockNetherBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.netherBrick.14.desc"), 14, "netherbrick/a1-netherbrick-red");
             blockNetherBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.netherBrick.15.desc"), 15, "netherbrick/a1-netherbrick-redsmall");
-            blockNetherBrick.carverHelper.register(blockNetherBrick, "netherBrick");
-            Carving.chisel.registerOre("netherBrick", "netherBrick");
+            blockNetherBrick.carverHelper.register(blockNetherBrick, "nether_brick");
+            Carving.chisel.registerOre("nether_brick", "nether_brick");
         }
 
         if(Configurations.featureEnabled("netherRack"))
         {
             blockNetherrack = (BlockCarvable) new BlockCarvable().setHardness(0.4F).setStepSound(Block.soundTypeStone);
-            Carving.chisel.addVariation("hellrock", Blocks.netherrack, 0, 0);
+            Carving.chisel.addVariation("netherrack", Blocks.netherrack, 0, 0);
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.1.desc"), 1, "netherrack/a1-netherrack-bloodgravel");
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.2.desc"), 2, "netherrack/a1-netherrack-bloodrock");
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.3.desc"), 3, "netherrack/a1-netherrack-bloodrockgrey");
@@ -595,14 +595,14 @@ public class ChiselBlocks
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.12.desc"), 12, "netherrack/a1-netherrack-meatrock");
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.13.desc"), 13, "netherrack/a1-netherrack-red");
             blockNetherrack.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.hellrock.14.desc"), 14, "netherrack/a1-netherrack-wells");
-            blockNetherrack.carverHelper.register(blockNetherrack, "hellrock");
-            Carving.chisel.registerOre("hellrock", "blockNetherrack");
+            blockNetherrack.carverHelper.register(blockNetherrack, "netherrack");
+            Carving.chisel.registerOre("netherrack", "netherrack");
         }
 
         if(Configurations.featureEnabled("cobblestoneMossy"))
         {
             blockCobblestoneMossy = (BlockCarvable) new BlockCarvable().setHardness(2.0F).setResistance(10.0F).setStepSound(Block.soundTypeStone);
-            Carving.chisel.addVariation("stoneMoss", Blocks.mossy_cobblestone, 0, 0);
+            Carving.chisel.addVariation("mossy_cobblestone", Blocks.mossy_cobblestone, 0, 0);
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.1.desc"), 1, "cobblestonemossy/terrain-cobb-brickaligned");
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.2.desc"), 2, "cobblestonemossy/terrain-cob-detailedbrick");
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.3.desc"), 3, "cobblestonemossy/terrain-cob-smallbrick");
@@ -618,8 +618,8 @@ public class ChiselBlocks
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.13.desc"), 13, "cobblestonemossy/terrain-pistonback-darkemboss");
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.14.desc"), 14, "cobblestonemossy/terrain-pistonback-darkmarker");
             blockCobblestoneMossy.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneMoss.15.desc"), 15, "cobblestonemossy/terrain-pistonback-darkpanel");
-            blockCobblestoneMossy.carverHelper.register(blockCobblestoneMossy, "stoneMoss");
-            Carving.chisel.registerOre("stoneMoss", "blockCobblestoneMossy");
+            blockCobblestoneMossy.carverHelper.register(blockCobblestoneMossy, "mossy_cobblestone");
+            Carving.chisel.registerOre("mossy_cobblestone", "mossy_cobblestone");
         }
 
         if(Configurations.featureEnabled("stoneBrick"))
@@ -630,9 +630,9 @@ public class ChiselBlocks
                 if(i == 1)
                 {
                     if(Configurations.allowMossy)
-                        Carving.chisel.addVariation("stoneBrick", Blocks.stonebrick, i, i);
+                        Carving.chisel.addVariation("stonebrick", Blocks.stonebrick, i, i);
                 } else
-                    Carving.chisel.addVariation("stoneBrick", Blocks.stonebrick, i, i);
+                    Carving.chisel.addVariation("stonebrick", Blocks.stonebrick, i, i);
             }
             stoneBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneBrick.4.desc"), 4, "stonebrick/smallbricks");
             stoneBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneBrick.5.desc"), 5, "stonebrick/largebricks");
@@ -646,24 +646,24 @@ public class ChiselBlocks
             stoneBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneBrick.13.desc"), 13, "stonebrick/sunken");
             stoneBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneBrick.14.desc"), 14, "stonebrick/ornatepanel");
             stoneBrick.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.stoneBrick.15.desc"), 15, "stonebrick/poison");
-            stoneBrick.carverHelper.register(stoneBrick, "stoneBrick");
-            Carving.chisel.registerOre("stoneBrick", "blockStoneBrick");
+            stoneBrick.carverHelper.register(stoneBrick, "stonebrick");
+            Carving.chisel.registerOre("stonebrick", "stonebrick");
         }
 
         if(Configurations.featureEnabled("snakestone"))
         {
             blockSnakestone = (BlockSnakestone) new BlockSnakestone("Chisel:snakestone/snake/").setBlockName("snakestoneStone");
-            GameRegistry.registerBlock(blockSnakestone, ItemCarvable.class, "snakestoneStone");
+            GameRegistry.registerBlock(blockSnakestone, ItemCarvable.class, "stone_snakestone");
             //LanguageRegistry.addName(new ItemStack(blockSnakestone, 1, 1), "Stone snake block head");
             //LanguageRegistry.addName(new ItemStack(blockSnakestone, 1, 13), "Stone snake block body");
-            Carving.chisel.addVariation("stoneBrick", blockSnakestone, 1, 16);
-            Carving.chisel.addVariation("stoneBrick", blockSnakestone, 13, 17);
+            Carving.chisel.addVariation("stonebrick", blockSnakestone, 1, 16);
+            Carving.chisel.addVariation("stonebrick", blockSnakestone, 13, 17);
         }
 
         if(Configurations.featureEnabled("dirt"))
         {
             blockDirt = (BlockCarvable) new BlockCarvable(Material.ground).setHardness(0.5F).setStepSound(Block.soundTypeGravel).setBlockName("dirt.default");
-            Carving.chisel.addVariation("blockDirt", Blocks.dirt, 0, 0);
+            Carving.chisel.addVariation("dirt", Blocks.dirt, 0, 0);
             blockDirt.carverHelper.setChiselBlockName("Dirt");
             //blockDirt.carverHelper.addVariation("Dirt", 0, Blocks.dirt);
             blockDirt.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockDirt.0.desc"), 0, "dirt/bricks");
@@ -679,10 +679,10 @@ public class ChiselBlocks
             blockDirt.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockDirt.10.desc"), 10, "dirt/vert");
             blockDirt.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockDirt.11.desc"), 11, "dirt/layers");
             blockDirt.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockDirt.12.desc"), 12, "dirt/vertical");
-            blockDirt.carverHelper.register(blockDirt, "blockDirt");
+            blockDirt.carverHelper.register(blockDirt, "dirt");
             blockDirt.setHarvestLevel("shovel", 0);
             OreDictionary.registerOre("blockDirt", blockDirt);
-            Carving.chisel.registerOre("blockDirt", "blockDirt");
+            Carving.chisel.registerOre("dirt", "blockDirt");
         }
 
         if(Configurations.featureEnabled("ice"))
@@ -727,8 +727,8 @@ public class ChiselBlocks
                 blockIcePillar.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.icePillar.13.desc"), 13, "icepillar/a1-stonepillar-plaintopgreek");
                 blockIcePillar.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.icePillar.14.desc"), 14, "icepillar/a1-stonepillar-greekbottomgreek");
                 blockIcePillar.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.icePillar.15.desc"), 15, "icepillar/a1-stonepillar-plainbottomgreek");
-                blockIcePillar.carverHelper.register(blockIcePillar, "icePillar");
-                Carving.chisel.setGroupClass("icePillar", "ice");
+                blockIcePillar.carverHelper.register(blockIcePillar, "ice_pillar");
+                Carving.chisel.setGroupClass("ice_pillar", "ice");
             }
 
             if(Configurations.featureEnabled("iceStairs"))
@@ -758,18 +758,19 @@ public class ChiselBlocks
                     {
                         return new BlockMarbleIceStairs(block, meta, helper);
                     }
-                }, "iceStairs");
+                }, "ice_stairs");
             }
         }
 
         if(Configurations.featureEnabled("wood"))
         {
-            String[] plank_names = {"oak", "spruce", "birch", "jungle", "acacia", "dark-oak"};
+            String[] plank_names = { "oak", "spruce", "birch", "jungle", "acacia", "dark-oak" };
             String[] plank_ucnames = {"Oak", "Spruce", "Birch", "Jungle", "Acacia", "Dark Oak"};
             for(int i = 0; i < 6; i++)
             {
                 String n = plank_names[i];
                 String u = plank_ucnames[i];
+                final String orename = n.replace('-', '_') + "_planks";
 
                 blockPlanks[i] = (BlockCarvable) (new BlockCarvable()).setHardness(2.0F).setResistance(5.0F).setStepSound(Block.soundTypeWood);
                 blockPlanks[i].carverHelper.setChiselBlockName(u + " Wood Planks");
@@ -791,12 +792,12 @@ public class ChiselBlocks
                     blockPlanks[i].carverHelper.addVariation(u + " wood planks in disarray", 14, "planks-" + n + "/chaotic-hor");
                     blockPlanks[i].carverHelper.addVariation("Vertical " + n + " wood planks in disarray", 15, "planks-" + n + "/chaotic");
                 }
-                blockPlanks[i].carverHelper.register(blockPlanks[i], "wood-" + n);
-                Carving.chisel.addVariation("wood-" + n, Blocks.planks, i, 0);
+                blockPlanks[i].carverHelper.register(blockPlanks[i], orename);
+                Carving.chisel.addVariation(orename, Blocks.planks, i, 0);
                 Blocks.planks.setHarvestLevel("chisel", 0, i);
                 blockPlanks[i].setHarvestLevel("axe", 0);
 
-                Carving.chisel.setVariationSound("wood-" + n, Chisel.MOD_ID+":chisel.wood");
+                Carving.chisel.setVariationSound(orename, Chisel.MOD_ID+":chisel.wood");
             }
         }
 
@@ -820,13 +821,13 @@ public class ChiselBlocks
             blockObsidian.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.obsidian.14.desc"), 14, "obsidian/greek");
             blockObsidian.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.obsidian.15.desc"), 15, "obsidian/crate");
             blockObsidian.carverHelper.register(blockObsidian, "obsidian");
-            Carving.chisel.registerOre("obsidian", "blockObsidian");
+            Carving.chisel.registerOre("obsidian", "obsidian");
         }
 
         if(Configurations.featureEnabled("snakestoneObsidian"))
         {
             blockObsidianSnakestone = (BlockSnakestoneObsidian) new BlockSnakestoneObsidian("Chisel:snakestone/obsidian/").setBlockName("obsidianSnakestone").setHardness(50.0F).setResistance(2000.0F);
-            GameRegistry.registerBlock(blockObsidianSnakestone, ItemCarvable.class, "obsidianSnakestone");
+            GameRegistry.registerBlock(blockObsidianSnakestone, ItemCarvable.class, "obsidian_snakestone");
             //LanguageRegistry.addName(new ItemStack(blockObsidianSnakestone, 1, 1), "Obsidian snakestone head");
             //LanguageRegistry.addName(new ItemStack(blockObsidianSnakestone, 1, 13), "Obsidian snakestone body");
             Carving.chisel.addVariation("obsidian", blockObsidianSnakestone, 1, 16);
@@ -836,7 +837,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("ironBars"))
         {
             blockPaneIron = (BlockCarvablePane) new BlockCarvablePane(Material.iron, true).setHardness(0.3F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("fenceIron", Blocks.iron_bars, 0, 0);
+            Carving.chisel.addVariation("iron_bars", Blocks.iron_bars, 0, 0);
             blockPaneIron.carverHelper.addVariation("Iron bars without frame", 1, "ironpane/fenceIron");
             blockPaneIron.carverHelper.addVariation("Menacing iron bars", 2, "ironpane/barbedwire");
             blockPaneIron.carverHelper.addVariation("Iron cage bars", 3, "ironpane/cage");
@@ -846,13 +847,13 @@ public class ChiselBlocks
             blockPaneIron.carverHelper.addVariation("Ornate iron pane fence", 7, "ironpane/terrain-glass-ornatesteel");
             blockPaneIron.carverHelper.addVariation("Vertical iron bars", 8, "ironpane/bars");
             blockPaneIron.carverHelper.addVariation("Iron spikes", 9, "ironpane/spikes");
-            blockPaneIron.carverHelper.register(blockPaneIron, "fenceIron");
+            blockPaneIron.carverHelper.register(blockPaneIron, "iron_bars");
         }
 
         if(Configurations.featureEnabled("glassPane"))
         {
             blockPaneGlass = (BlockCarvablePane) new BlockCarvablePane(Material.glass, false).setHardness(0.3F).setStepSound(Block.soundTypeGlass);
-            Carving.chisel.addVariation("glassPane", Blocks.glass_pane, 0, 0);
+            Carving.chisel.addVariation("glass_pane", Blocks.glass_pane, 0, 0);
             blockPaneGlass.carverHelper.addVariation("Bubble glass pane", 1, "glasspane/terrain-glassbubble");
             blockPaneGlass.carverHelper.addVariation("Borderless glass pane", 2, "glasspane/terrain-glassnoborder");
             blockPaneGlass.carverHelper.addVariation("Screen pane", 3, "glasspane/terrain-glass-screen");
@@ -861,13 +862,13 @@ public class ChiselBlocks
             blockPaneGlass.carverHelper.addVariation("Chinese glass pane with golden frame", 13, "glasspane/chinese2");
             blockPaneGlass.carverHelper.addVariation("Japanese glass pane", 14, "glasspane/japanese");
             blockPaneGlass.carverHelper.addVariation("Ornate japanese glass pane", 15, "glasspane/japanese2");
-            blockPaneGlass.carverHelper.register(blockPaneGlass, "glassPane");
+            blockPaneGlass.carverHelper.register(blockPaneGlass, "glass_pane");
         }
 
         if(Configurations.featureEnabled("redstoneBlock"))
         {
             blockRedstone = (BlockCarvablePowered) (new BlockCarvablePowered(Material.iron)).setHardness(5.0F).setResistance(10.0F).setStepSound(Block.soundTypeMetal);
-            Carving.chisel.addVariation("blockRedstone", Blocks.redstone_block, 0, 0);
+            Carving.chisel.addVariation("redstone_block", Blocks.redstone_block, 0, 0);
             blockRedstone.carverHelper.addVariation("Smooth redstone", 1, "redstone/smooth");
             blockRedstone.carverHelper.addVariation("Large redstone block", 2, "redstone/block");
             blockRedstone.carverHelper.addVariation("Small redstone blocks", 3, "redstone/blocks");
@@ -883,8 +884,8 @@ public class ChiselBlocks
             blockRedstone.carverHelper.addVariation("Redstone supaplex circuit", 13, "redstone/supaplex");
             blockRedstone.carverHelper.addVariation("Redstone skulls", 14, "redstone/a1-blockredstone-skullred");
             blockRedstone.carverHelper.addVariation("Redstone Zelda block", 15, "redstone/a1-blockredstone-redstonezelda");
-            blockRedstone.carverHelper.register(blockRedstone, "blockRedstone");
-            Carving.chisel.registerOre("blockRedstone", "blockRedstone");
+            blockRedstone.carverHelper.register(blockRedstone, "redstone_block");
+            Carving.chisel.registerOre("redstone_block", "blockRedstone");
         }
 
         if(Configurations.featureEnabled("holystone"))
@@ -904,9 +905,9 @@ public class ChiselBlocks
             blockHolystone.carverHelper.addVariation("Fancy holystone tiles", 11, "holystone/fancy-tiles");
             blockHolystone.carverHelper.addVariation("Smooth holystone plate", 12, "holystone/plate");
             blockHolystone.carverHelper.addVariation("Holystone plate", 13, "holystone/plate-rough");
-            blockHolystone.carverHelper.register(blockHolystone, "blockHolystone");
+            blockHolystone.carverHelper.register(blockHolystone, "holystone");
             OreDictionary.registerOre("blockHolystone", blockHolystone);
-            Carving.chisel.registerOre("blockHolystone", "blockHolystone");
+            Carving.chisel.registerOre("holystone", "blockHolystone");
         }
 
         if(Configurations.featureEnabled("lavastone"))
@@ -919,9 +920,9 @@ public class ChiselBlocks
             blockLavastone.carverHelper.addVariation("Lava creeper in tiles", 4, "lavastone/creeper");
             blockLavastone.carverHelper.addVariation("Lava panel", 5, "lavastone/panel");
             blockLavastone.carverHelper.addVariation("Ornate lava panel", 6, "lavastone/panel-ornate");
-            blockLavastone.carverHelper.register(blockLavastone, "blockLavastone");
+            blockLavastone.carverHelper.register(blockLavastone, "lavastone");
             OreDictionary.registerOre("blockLavastone", blockLavastone);
-            Carving.chisel.registerOre("blockLavastone", "blockLavastone");
+            Carving.chisel.registerOre("lavastone", "blockLavastone");
         }
 
         if(Configurations.featureEnabled("fantasy"))
@@ -944,9 +945,9 @@ public class ChiselBlocks
             blockFft.carverHelper.addVariation("Fantasy block", 13, "fft/block");
             blockFft.carverHelper.addVariation("Fantasy bricks in disarray", 14, "fft/bricks-chaotic");
             blockFft.carverHelper.addVariation("Weared fantasy bricks", 15, "fft/bricks-wear");
-            blockFft.carverHelper.register(blockFft, "blockFft");
+            blockFft.carverHelper.register(blockFft, "fantasyblock");
             OreDictionary.registerOre("blockFft", blockFft);
-            Carving.chisel.registerOre("blockFft", "blockFft");
+            Carving.chisel.registerOre("fantasyblock", "blockFft");
         }
 
         if(Configurations.featureEnabled("carpet"))
@@ -970,9 +971,9 @@ public class ChiselBlocks
             blockCarpet.carverHelper.addVariation("Red carpet block", 14, "carpet/red");
             blockCarpet.carverHelper.addVariation("Black carpet block", 15, "carpet/black");
             blockCarpet.carverHelper.forbidChiseling = true;
-            blockCarpet.carverHelper.register(blockCarpet, "blockCarpet");
+            blockCarpet.carverHelper.register(blockCarpet, "carpet_block");
             OreDictionary.registerOre("blockCarpet", blockCarpet);
-            Carving.chisel.registerOre("blockCarpet", "blockCarpet");
+            Carving.chisel.registerOre("carpet_block", "blockCarpet");
         }
 
         if(Configurations.featureEnabled("carpetFloor"))
@@ -996,7 +997,7 @@ public class ChiselBlocks
             blockCarpetFloor.carverHelper.addVariation("Red carpet", 14, "carpet/red");
             blockCarpetFloor.carverHelper.addVariation("Black carpet", 15, "carpet/black");
             blockCarpetFloor.carverHelper.forbidChiseling = true;
-            blockCarpetFloor.carverHelper.register(blockCarpetFloor, "blockCarpetFloor");
+            blockCarpetFloor.carverHelper.register(blockCarpetFloor, "carpet");
 
             for(int i = 0; i < 16; i++)
             {
@@ -1011,7 +1012,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("bookshelf"))
         {
             blockBookshelf = (BlockCarvable) new BlockMarbleBookshelf().setHardness(1.5F).setStepSound(Block.soundTypeWood);
-            Carving.chisel.addVariation("blockBookshelf", Blocks.bookshelf, 0, 0);
+            Carving.chisel.addVariation("bookshelf", Blocks.bookshelf, 0, 0);
             blockBookshelf.carverHelper.addVariation("Bookshelf with rainbow colored books", 1, "bookshelf/rainbow");
             blockBookshelf.carverHelper.addVariation("Necromancer novice's bookshelf", 2, "bookshelf/necromancer-novice");
             blockBookshelf.carverHelper.addVariation("Necromancer's bookshelf", 3, "bookshelf/necromancer");
@@ -1020,9 +1021,9 @@ public class ChiselBlocks
             blockBookshelf.carverHelper.addVariation("Hoarder's bookshelf", 6, "bookshelf/hoarder");
             blockBookshelf.carverHelper.addVariation("Bookshelf filled to brim with boring pastel books", 7, "bookshelf/brim");
             blockBookshelf.carverHelper.addVariation("Historician's bookshelf", 8, "bookshelf/historician");
-            blockBookshelf.carverHelper.register(blockBookshelf, "blockBookshelf");
+            blockBookshelf.carverHelper.register(blockBookshelf, "bookshelf");
             blockBookshelf.setHarvestLevel("axe", 0);
-            Carving.chisel.registerOre("blockBookshelf", "blockBookshelf");
+            Carving.chisel.registerOre("bookshelf", "bookshelf");
         }
 
         if(Configurations.featureEnabled("futuristicArmorPlating"))
@@ -1045,9 +1046,9 @@ public class ChiselBlocks
             blockTyrian.carverHelper.addVariation("Black futuristic armor plating tiles", 13, "tyrian/black2");
             blockTyrian.carverHelper.addVariation("Black futuristic armor plating block with an opening", 14, "tyrian/opening");
             blockTyrian.carverHelper.addVariation("Futuristic armor plating with shining metal bits", 15, "tyrian/plate");
-            blockTyrian.carverHelper.register(blockTyrian, "blockTyrian");
+            blockTyrian.carverHelper.register(blockTyrian, "tyrian");
             OreDictionary.registerOre("blockTyrian", blockTyrian);
-            Carving.chisel.registerOre("blockTyrian", "blockTyrian");
+            Carving.chisel.registerOre("tyrian", "blockTyrian");
         }
 
 
@@ -1071,7 +1072,7 @@ public class ChiselBlocks
             blockTemple.carverHelper.addVariation("Small temple tiles", 13, "temple/smalltiles");
             blockTemple.carverHelper.addVariation("Light temple tiles", 14, "temple/tiles-light");
             blockTemple.carverHelper.addVariation("Small light temple tiles", 15, "temple/smalltiles-light");
-            blockTemple.carverHelper.register(blockTemple, "blockTemple");
+            blockTemple.carverHelper.register(blockTemple, "templeblock");
 
             if(Configurations.featureEnabled("templeBlockMossy"))
             {
@@ -1093,7 +1094,7 @@ public class ChiselBlocks
                 blockTempleMossy.carverHelper.addVariation("Small mossy temple tiles", 13, "templemossy/smalltiles");
                 blockTempleMossy.carverHelper.addVariation("Light mossy temple tiles", 14, "templemossy/tiles-light");
                 blockTempleMossy.carverHelper.addVariation("Small light mossy  temple tiles", 15, "templemossy/smalltiles-light");
-                blockTempleMossy.carverHelper.register(blockTempleMossy, "blockTempleMossy");
+                blockTempleMossy.carverHelper.register(blockTempleMossy, "mossy_templeblock");
             }
         }
 
@@ -1101,15 +1102,15 @@ public class ChiselBlocks
         {
             blockCloud = (BlockCloud) new BlockCloud().setHardness(0.2F).setLightOpacity(3).setStepSound(Block.soundTypeCloth);
             blockCloud.carverHelper.addVariation("Cloud block", 0, "cloud/cloud");
-            blockCloud.carverHelper.register(blockCloud, "blockCloud");
-            OreDictionary.registerOre("blockCloud", blockCloud);
-            Carving.chisel.registerOre("blockCloud", "blockCloud");
+            blockCloud.carverHelper.register(blockCloud, "cloud");
+            OreDictionary.registerOre("cloud", blockCloud);
+            Carving.chisel.registerOre("cloud", "cloud");
         }
 
         if(Configurations.featureEnabled("factory"))
         {
             blockFactory = (BlockCarvable) new BlockCarvable().setHardness(2.0F).setResistance(10F).setStepSound(Chisel.soundMetalFootstep);
-            blockFactory.carverHelper.setChiselBlockName("blockFactory");
+            blockFactory.carverHelper.setChiselBlockName("factoryblock");
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.0.desc"), 0, "factory/dots");
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.1.desc"), 1, "factory/rust2");
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.2.desc"), 2, "factory/rust");
@@ -1126,7 +1127,7 @@ public class ChiselBlocks
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.13.desc"), 13, "factory/plating");
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.14.desc"), 14, "factory/rustplates");
             blockFactory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockFactory.15.desc"), 15, "factory/column");
-            blockFactory.carverHelper.register(blockFactory, "blockFactory");
+            blockFactory.carverHelper.register(blockFactory, "factoryblock");
         }
 
         // 1.7! Let's go! Let's go-go!
@@ -1140,7 +1141,7 @@ public class ChiselBlocks
 
         if(Configurations.featureEnabled("glassStained")) for(int i = 0; i < 16; i++)
         {
-            final String blockName = "stainedGlass" + sGNames[i].replaceAll(" ", "");
+            final String blockName = "stained_glass_" + sGNames[i].replaceAll(" ", "").toLowerCase();
             String oreName = "stainedGlass" + sGNames[i].replaceAll(" ", "");
             String texName = "glassdyed/" + sGNames[i].toLowerCase().replaceAll(" ", "") + "-";
             int glassPrefix = (i & 3) << 2;
@@ -1168,7 +1169,7 @@ public class ChiselBlocks
 
         if(Configurations.featureEnabled("glassStainedPane")) for(int i = 0; i < 16; i++)
         {
-            final String blockName = "stainedGlassPane" + sGNames[i].replaceAll(" ", "");
+            final String blockName = "stained_glass_pane_" + sGNames[i].replaceAll(" ", "").toLowerCase();
             String oreName = "stainedGlassPane" + sGNames[i].replaceAll(" ", "");
             String texName = "glasspanedyed/" + sGNames[i].toLowerCase().replaceAll(" ", "") + "-";
             Carving.chisel.addVariation(blockName, Blocks.stained_glass_pane, i, 0);
@@ -1210,7 +1211,7 @@ public class ChiselBlocks
             blockPaperwall.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.paperwall.7.desc"), 7, "paper/plain");
             blockPaperwall.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.paperwall.8.desc"), 8, "paper/door");
 
-            blockPaperwall.carverHelper.register(blockPaperwall, "blockPaperwall");
+            blockPaperwall.carverHelper.register(blockPaperwall, "paperwall");
 
         }
 
@@ -1221,7 +1222,7 @@ public class ChiselBlocks
 
             for(int i = 0; i < 16; i++)
                 blockWoolenClay.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.woolenClay." + i + ".desc"), i, "woolenClay/" + sGNames[i].replaceAll(" ", "").toLowerCase());
-            blockWoolenClay.carverHelper.register(blockWoolenClay, "blockWoolenClay");
+            blockWoolenClay.carverHelper.register(blockWoolenClay, "woolen_clay");
 
 
         }
@@ -1229,7 +1230,7 @@ public class ChiselBlocks
         if(Configurations.featureEnabled("laboratory"))
         {
             blockLaboratory = (BlockCarvable) new BlockCarvable().setHardness(2.0F).setResistance(10F).setStepSound(Chisel.soundMetalFootstep);
-            blockLaboratory.carverHelper.setChiselBlockName("blockLaboratory");
+            blockLaboratory.carverHelper.setChiselBlockName("laboratoryblock");
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.0.desc"), 0, "laboratory/wallpanel");
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.1.desc"), 1, "laboratory/dottedpanel");
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.2.desc"), 2, "laboratory/largewall");
@@ -1246,7 +1247,7 @@ public class ChiselBlocks
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.13.desc"), 13, "laboratory/directionright");
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.14.desc"), 14, "laboratory/directionleft");
             blockLaboratory.carverHelper.addVariation(StatCollector.translateToLocal("chisel.tile.blockLaboratory.15.desc"), 15, "laboratory/infocon");
-            blockLaboratory.carverHelper.register(blockLaboratory, "blockLaboratory");
+            blockLaboratory.carverHelper.register(blockLaboratory, "laboratoryblock");
         }
 
         Blocks.stone.setHarvestLevel("chisel", 0, 0);

--- a/src/main/java/info/jbcs/minecraft/chisel/carving/CarvableHelper.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/carving/CarvableHelper.java
@@ -290,7 +290,7 @@ public class CarvableHelper
     void registerBlock(Block block, String name, Class cl)
     {
         block.setBlockName(name);
-        GameRegistry.registerBlock(block, cl, "chisel." + name);
+        GameRegistry.registerBlock(block, cl, name);
         chiselBlocks.add(block);
     }
 

--- a/src/main/java/info/jbcs/minecraft/chisel/item/ItemCarvable.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/item/ItemCarvable.java
@@ -29,13 +29,6 @@ public class ItemCarvable extends ItemBlock
         return i;
     }
 
-    //TODO- to fix some, one must break some
-    @Override
-    public String getUnlocalizedName(ItemStack itemstack)
-    {
-        return "chisel." + Block.getBlockFromItem(this).getUnlocalizedName();
-    }
-
     @Override
     public IIcon getIconFromDamage(int damage)
     {

--- a/src/main/resources/assets/chisel/lang/en_US.lang
+++ b/src/main/resources/assets/chisel/lang/en_US.lang
@@ -9,7 +9,7 @@ item.cloudBottle.name=Cloud In A Bottle
 # Have fun! ~zombiepig333
 
 #Cobblestone Blocks
-chisel.tile.cobblestone.name=Cobblestone
+tile.cobblestone.name=Cobblestone
 chisel.tile.cobblestone.0.desc=Aligned Cobblestone Bricks
 chisel.tile.cobblestone.1.desc=Detailed Cobblestone Bricks
 chisel.tile.cobblestone.2.desc=Small Cobblestone Bricks
@@ -27,10 +27,10 @@ chisel.tile.cobblestone.13.desc=Cobblestone with Light Panel
 chisel.tile.cobblestone.14.desc=Cobblestone with Dark Panel
 
 #Sandstone Blocks
-chisel.tile.sandstone.name=Sandstone
+tile.sandstone.name=Sandstone
 
 #Marble Blocks
-chisel.tile.marble.name=Marble
+tile.marble.name=Marble
 chisel.tile.marble.0.desc=Raw Marble
 chisel.tile.marble.1.desc=Marble Brick
 chisel.tile.marble.2.desc=Classic Marble Panel
@@ -49,7 +49,7 @@ chisel.tile.marble.14.desc=Fancy Marble Tiles
 chisel.tile.marble.15.desc=Marble Blocks
 
 #Marble Slabs
-chisel.tile.marbleSlab.name=Marble Slab
+tile.marble_slab.name=Marble Slab
 chisel.tile.marbleSlab.0.desc=Raw Marble Slab
 chisel.tile.marbleSlab.1.desc=Marble Brick Slab
 chisel.tile.marbleSlab.2.desc=Classic Marble Panel Slab
@@ -68,7 +68,7 @@ chisel.tile.marbleSlab.14.desc=Fancy Marble Tiled Slab
 chisel.tile.marbleSlab.15.desc=Marble Blocks Slab
 
 #Marble Pillars (old)
-chisel.tile.marblePillar.name=Marble Pillar
+tile.marble_pillar.name=Marble Pillar
 chisel.tile.marblePillarOld.0.desc=Marble Pillar
 chisel.tile.marblePillarOld.1.desc=Marble Pillar Capstone
 chisel.tile.marblePillarOld.2.desc=Marble Pillar Base
@@ -105,7 +105,7 @@ chisel.tile.marblePillar.14.desc=Carved Pillar Capstone
 chisel.tile.marblePillar.15.desc=Ornamental Pillar Capstone
 
 #Marble Slabs (old)
-chisel.tile.marblePillarSlab.name=Marble Pillar Slab
+tile.marble_pillar_slab.name=Marble Pillar Slab
 chisel.tile.marblePillarSlabOld.0.desc=Marble Pillar Slab
 chisel.tile.marblePillarSlabOld.1.desc=Marble Pllar Capstone Slab
 chisel.tile.marblePillarSlabOld.2.desc=Marble Pillar Base Slab
@@ -144,14 +144,14 @@ chisel.tile.marblePillarSlab.15.desc=Ornamental Pillar Capstone Slab
 #Marble Stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.marbleStairs.0.name=Marble Stairs
-chisel.tile.marbleStairs.1.name=Marble Stairs
-chisel.tile.marbleStairs.2.name=Marble Stairs
-chisel.tile.marbleStairs.3.name=Marble Stairs
-chisel.tile.marbleStairs.4.name=Marble Stairs
-chisel.tile.marbleStairs.5.name=Marble Stairs
-chisel.tile.marbleStairs.6.name=Marble Stairs
-chisel.tile.marbleStairs.7.name=Marble Stairs
+tile.marble_stairs.0.name=Marble Stairs
+tile.marble_stairs.1.name=Marble Stairs
+tile.marble_stairs.2.name=Marble Stairs
+tile.marble_stairs.3.name=Marble Stairs
+tile.marble_stairs.4.name=Marble Stairs
+tile.marble_stairs.5.name=Marble Stairs
+tile.marble_stairs.6.name=Marble Stairs
+tile.marble_stairs.7.name=Marble Stairs
 
 #These are bugged.... so sad :,(
 chisel.tile.marbleStairs.0.desc=Raw Marble Stairs
@@ -172,7 +172,7 @@ chisel.tile.marbleStairs.14.desc=Fancy Marble Tiled Stairs
 chisel.tile.marbleStairs.15.desc=Marble Block Stairs
 
 #Limestone
-chisel.tile.limestone.name=Limestone
+tile.limestone.name=Limestone
 chisel.tile.limestone.0.desc=Limestone
 chisel.tile.limestone.1.desc=Small Limestone Tiles
 chisel.tile.limestone.2.desc=French Limestone Tiles
@@ -191,7 +191,7 @@ chisel.tile.limestone.14.desc=Limestone with Light Panel
 chisel.tile.limestone.15.desc=Limestone with Dark Panel
 
 #Limestone Slabs
-chisel.tile.limestoneSlab.name=Limestone Slab
+tile.limestone_slab.name=Limestone Slab
 chisel.tile.limestoneSlab.0.desc=Limestone Slab
 chisel.tile.limestoneSlab.1.desc=Small Limestone Tiled Slab
 chisel.tile.limestoneSlab.2.desc=French Limestone Tiled Slab
@@ -212,14 +212,14 @@ chisel.tile.limestoneSlab.15.desc=Limestone Slab with Dark Panel
 #Limestone Stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.limestoneStairs.0.name=Limestone Stairs
-chisel.tile.limestoneStairs.1.name=Limestone Stairs
-chisel.tile.limestoneStairs.2.name=Limestone Stairs
-chisel.tile.limestoneStairs.3.name=Limestone Stairs
-chisel.tile.limestoneStairs.4.name=Limestone Stairs
-chisel.tile.limestoneStairs.5.name=Limestone Stairs
-chisel.tile.limestoneStairs.6.name=Limestone Stairs
-chisel.tile.limestoneStairs.7.name=Limestone Stairs
+tile.limestone_stairs.0.name=Limestone Stairs
+tile.limestone_stairs.1.name=Limestone Stairs
+tile.limestone_stairs.2.name=Limestone Stairs
+tile.limestone_stairs.3.name=Limestone Stairs
+tile.limestone_stairs.4.name=Limestone Stairs
+tile.limestone_stairs.5.name=Limestone Stairs
+tile.limestone_stairs.6.name=Limestone Stairs
+tile.limestone_stairs.7.name=Limestone Stairs
 
 #These are bugged.... so sad :,(
 chisel.tile.limestoneStairs.0.desc=Limestone Stairs
@@ -240,7 +240,7 @@ chisel.tile.limestoneStairs.14.desc=Limestone Stairs with Light Panel
 chisel.tile.limestoneStairs.15.desc=Limestone Stairs with Dark Panel
 
 #Factory Blocks
-chisel.tile.blockFactory.name=Factory Block
+tile.factoryblock.name=Factory Block
 chisel.tile.blockFactory.0.desc=Rusty Metal Plate with Dotted Pattern
 chisel.tile.blockFactory.1.desc=Rusty Metal Plate
 chisel.tile.blockFactory.2.desc=Very Rusty Metal Plate
@@ -259,7 +259,7 @@ chisel.tile.blockFactory.14.desc=Rusty Metal Plates
 chisel.tile.blockFactory.15.desc=Weared Metal Column
 
 #Diamond blocks
-chisel.tile.diamond.name=Diamond Block
+tile.diamond_block.name=Diamond Block
 chisel.tile.diamond.1.desc=Embossed Diamond Block
 chisel.tile.diamond.2.desc=Diamond Block with Panel
 chisel.tile.diamond.3.desc=Diamond Cells
@@ -274,12 +274,12 @@ chisel.tile.diamond.11.desc=Zelda Diamond Block
 chisel.tile.diamond.12.desc=Diamond Block with Ornate Layer
 
 #Snakestone
-chisel.tile.snakestoneSand.name=Sand Snakestone
-chisel.tile.snakestoneStone.name=Stone Snakestone
-chisel.tile.snakestoneObsidian.name=Obsidian Snakestone
+tile.snakestoneSand.name=Sand Snakestone
+tile.snakestoneStone.name=Stone Snakestone
+tile.obsidianSnakestone.name=Obsidian Snakestone
 
 #Glass blocks
-chisel.tile.glass.name=Glass
+tile.glass.name=Glass
 chisel.tile.glass.1.desc=Bubble Glass
 chisel.tile.glass.2.desc=Chinese Glass
 chisel.tile.glass.3.desc=Japanese(?) Glass
@@ -297,7 +297,7 @@ chisel.tile.glass.14.desc=Thin Grid Glass
 chisel.tile.glass.15.desc=Modern Iron Fence
 
 #Sandstone
-chisel.tile.sandstone.name=Sandstone
+tile.sandstone.name=Sandstone
 chisel.tile.sandstone.3.desc=Faded Sandstone
 chisel.tile.sandstone.4.desc=Sandstone Pillar
 chisel.tile.sandstone.5.desc=Sandstone Pillar Capstone
@@ -313,11 +313,11 @@ chisel.tile.sandstone.14.desc=Sandstone Mosaic
 chisel.tile.sandstone.15.desc=Stacked Sandstone Tiles
 
 #Sandstone scribbles
-chisel.tile.sandstoneScribbles.name=Sandstone Scribbles
+tile.sandstone_scribbles.name=Sandstone Scribbles
 chisel.tile.sandstoneScribbles.desc=Sandstone scribbles
 
 #Concrete
-chisel.tile.blockConcrete.name=Concrete
+tile.concrete.name=Concrete
 chisel.tile.blockConcrete.0.desc=Concrete
 chisel.tile.blockConcrete.1.desc=Concrete Block
 chisel.tile.blockConcrete.2.desc=Concrete Double Slab
@@ -331,10 +331,10 @@ chisel.tile.blockConcrete.9.desc=Partly Weathered Concrete Block
 chisel.tile.blockConcrete.10.desc=Asphalt
 
 #Road Line
-chisel.tile.roadLine.name=Road Lines
+tile.roadLine.name=Road Lines
 
 #Iron Blocks
-chisel.tile.iron.name=Iron Block
+tile.iron_block.name=Iron Block
 chisel.tile.iron.1.desc=Large Iron Ingots
 chisel.tile.iron.2.desc=Small Iron Ingots
 chisel.tile.iron.3.desc=Iron Gears
@@ -352,7 +352,7 @@ chisel.tile.iron.14.desc=Iron Vents
 chisel.tile.iron.15.desc=Simple Iron Block
 
 #Gold Blocks
-chisel.tile.gold.name=Gold Block
+tile.gold_block.name=Gold Block
 chisel.tile.gold.1.desc=Large Golden Ingots
 chisel.tile.gold.2.desc=Small Golden Ingots
 chisel.tile.gold.3.desc=Golden Bricks
@@ -369,7 +369,7 @@ chisel.tile.gold.13.desc=Golden Star in Obsidian
 chisel.tile.gold.14.desc=Simple Gold Block
 
 #Glowstone
-chisel.tile.lightstone.name=Glowstone
+tile.glowstone.name=Glowstone
 chisel.tile.lightstone.1.desc=Cobble Glowstone Block
 chisel.tile.lightstone.2.desc=Corroded Glowstone Blocks
 chisel.tile.lightstone.3.desc=Glowstone Blocks with Glass
@@ -387,7 +387,7 @@ chisel.tile.lightstone.14.desc=Glowstone Bismuth
 chisel.tile.lightstone.15.desc=Glowstone Bismuth Panel
 
 #Lapis blocks
-chisel.tile.lapis.name=Lapis Block
+tile.lapis_block.name=Lapis Block
 chisel.tile.lapis.1.desc=Chunky Lapis Block
 chisel.tile.lapis.2.desc=Dark Lapis Block
 chisel.tile.lapis.3.desc=Zelda Lapis Block
@@ -398,7 +398,7 @@ chisel.tile.lapis.7.desc=Smooth Lapis
 chisel.tile.lapis.8.desc=Lapis with Ornate Layer
 
 #Emerald Blocks
-chisel.tile.emerald.name=Emerald Block
+tile.emerald_block.name=Emerald Block
 chisel.tile.emerald.1.desc=Emerald Panel
 chisel.tile.emerald.2.desc=Classic emerald Panel
 chisel.tile.emerald.3.desc=Smooth Emerald
@@ -412,7 +412,7 @@ chisel.tile.emerald.10.desc=Small Ornate Emerald Blocks
 chisel.tile.emerald.11.desc=Ornate Emerald Block
 
 #Nether Brick
-chisel.tile.netherBrick.name=Nether Brick
+tile.nether_brick.name=Nether Brick
 chisel.tile.netherBrick.1.desc=Blue Nether Brick
 chisel.tile.netherBrick.2.desc=Spattered Nether Brick
 chisel.tile.netherBrick.3.desc=Nether Brick made of Guts
@@ -430,7 +430,7 @@ chisel.tile.netherBrick.14.desc=Red Nether Brick
 chisel.tile.netherBrick.15.desc=Small Red Nether Brick
 
 #Netherrack
-chisel.tile.hellrock.name=Netherrack
+tile.netherrack.name=Netherrack
 chisel.tile.hellrock.1.desc=Nethergravel with Blood
 chisel.tile.hellrock.2.desc=Netherrack with Blood
 chisel.tile.hellrock.3.desc=Darker Netherrack with Blood
@@ -447,7 +447,7 @@ chisel.tile.hellrock.13.desc=Dark Red Netherrack
 chisel.tile.hellrock.14.desc=Netherrack with Flowing Lava
 
 #Mossy Stone
-chisel.tile.stoneMoss.name=Mossy Cobblestone
+tile.mossy_cobblestone.name=Mossy Cobblestone
 chisel.tile.stoneMoss.1.desc=Aligned Mossy Cobblestone Bricks
 chisel.tile.stoneMoss.2.desc=Detailed Mossy Cobblestone Bricks
 chisel.tile.stoneMoss.3.desc=Small Mossy Cobblestone Bricks
@@ -465,7 +465,7 @@ chisel.tile.stoneMoss.14.desc=Mossy Cobblestone with Light Panel
 chisel.tile.stoneMoss.15.desc=Mossy Cobblestone with Dark Panel
 
 #Stone Bricks
-chisel.tile.stoneBrick.name=Stone Bricks
+tile.stonebrick.name=Stone Bricks
 chisel.tile.stoneBrick.4.desc=Small Stone Bricks
 chisel.tile.stoneBrick.5.desc=Wide Stone Bricks
 chisel.tile.stoneBrick.6.desc=Small Disordered Stone Bricks
@@ -480,7 +480,7 @@ chisel.tile.stoneBrick.14.desc=Ornate Stone Panel
 chisel.tile.stoneBrick.15.desc=Poison Stone Brick
 
 #Dirt
-chisel.tile.blockDirt.name=Dirt
+tile.dirt.name=Dirt
 chisel.tile.blockDirt.0.desc=Dirt Bricks in Disarray
 chisel.tile.blockDirt.1.desc=Dirt Bricks Imitating Nether Brick Design
 chisel.tile.blockDirt.2.desc=Dirt Bricks
@@ -496,7 +496,7 @@ chisel.tile.blockDirt.11.desc=Dirt Layers
 chisel.tile.blockDirt.12.desc=Crumbling Dirt
 
 #Ice
-chisel.tile.ice.name=Ice
+tile.ice.name=Ice
 chisel.tile.ice.1.desc=Rough Ice Block
 chisel.tile.ice.2.desc=Cobble-ice
 chisel.tile.ice.3.desc=Large Rough Ice Bricks
@@ -514,7 +514,7 @@ chisel.tile.ice.14.desc=Ice Bismuth Block
 chisel.tile.ice.15.desc=Ice Poison Block
 
 #Ice Pillars
-chisel.tile.icePillar.name=Ice Pillar
+tile.ice_pillar.name=Ice Pillar
 chisel.tile.icePillar.0.desc=Ice Pillar
 chisel.tile.icePillar.1.desc=Ice Pillar Capstone
 chisel.tile.icePillar.2.desc=Ice Pillar Base
@@ -533,15 +533,15 @@ chisel.tile.icePillar.14.desc=Greek Ice Pillar Ornate Base
 chisel.tile.icePillar.15.desc=Plain Ice Pillar Ornate Base
 
 #Ice Stairs
-chisel.tile.iceStairs.name=Ice Stairs
-chisel.tile.chisel.iceStairs.0.name=Ice Stairs
-chisel.tile.chisel.iceStairs.1.name=Ice Stairs
-chisel.tile.chisel.iceStairs.2.name=Ice Stairs
-chisel.tile.chisel.iceStairs.3.name=Ice Stairs
-chisel.tile.chisel.iceStairs.4.name=Ice Stairs
-chisel.tile.chisel.iceStairs.5.name=Ice Stairs
-chisel.tile.chisel.iceStairs.6.name=Ice Stairs
-chisel.tile.chisel.iceStairs.7.name=Ice Stairs
+tile.ice_stairs.name=Ice Stairs
+tile.ice_stairs.0.name=Ice Stairs
+tile.ice_stairs.1.name=Ice Stairs
+tile.ice_stairs.2.name=Ice Stairs
+tile.ice_stairs.3.name=Ice Stairs
+tile.ice_stairs.4.name=Ice Stairs
+tile.ice_stairs.5.name=Ice Stairs
+tile.ice_stairs.6.name=Ice Stairs
+tile.ice_stairs.7.name=Ice Stairs
 chisel.tile.iceStairs.0.desc=Ice Stairs
 chisel.tile.iceStairs.1.desc=Rough Ice Stairs
 chisel.tile.iceStairs.2.desc=Cobble-ice Stairs
@@ -560,7 +560,7 @@ chisel.tile.iceStairs.14.desc=Ice Bismuth Stairs
 chisel.tile.iceStairs.15.desc=Ice Poison Stairs
 
 #Obsidian
-chisel.tile.obsidian.name=Obsidian
+tile.obsidian.name=Obsidian
 chisel.tile.obsidian.1.desc=Large Obsidian Pillar
 chisel.tile.obsidian.2.desc=Obsidian Pillar
 chisel.tile.obsidian.3.desc=Chiseled Obsidian
@@ -578,98 +578,92 @@ chisel.tile.obsidian.14.desc=Light Obsidian Blocks with Greek Decor
 chisel.tile.obsidian.15.desc=Small Obsidian Blocks inside an Oak Wood Crate
 
 #Wood
-chisel.tile.wood-oak.name=Oak Wood
-chisel.tile.wood-birch.name=Birch Wood
-chisel.tile.wood-spruce.name=Spruce Wood
-chisel.tile.wood-jungle.name=Jungle Wood
-chisel.tile.wood-dark-oak.name=Dark Oak Wood
-chisel.tile.wood-acacia.name=Acacia Wood
+tile.oak_planks.name=Oak Wood
+tile.birch_planks.name=Birch Wood
+tile.spruce_planks.name=Spruce Wood
+tile.jungle_planks.name=Jungle Wood
+tile.dark_oak_planks.name=Dark Oak Wood
+tile.acacia_planks.name=Acacia Wood
 
 #Remember to do the descriptions.
 
-#Obsidian Snakestone
-chisel.tile.obsidianSnakestone.name=Obsidian Snakestone
-
 #Iron Fence
-chisel.tile.fenceIron=Iron Bars
+tile.iron_bars.name=Iron Bars
 
 #Glass Panes
-chisel.tile.glassPane=Glass Pane
+tile.glass_pane.name=Glass Pane
 
 #Redstone block
-chisel.tile.blockRedstone.name=Redstone Block
+tile.redstone_block.name=Redstone Block
 
 #Holystone
-chisel.tile.blockHolystone.name=Holystone
+tile.holystone.name=Holystone
 
 #Lavastone
-chisel.tile.blockLavastone.name=Lavastone
+tile.lavastone.name=Lavastone
 
 #Carpet
-chisel.tile.blockCarpet.name=Carpet
+tile.carpet_block.name=Carpet
 
 #Carpet floor
-chisel.tile.blockCarpetFloor.name=Floor Carpet
+tile.carpet.name=Floor Carpet
 
 #Bookshelf
-chisel.tile.blockBookshelf.name=Bookshelf
+tile.bookshelf.name=Bookshelf
 
 #Tyrian
-chisel.tile.blockTyrian.name=Tyrian
+tile.tyrian.name=Tyrian
 
 #Temple
-chisel.tile.blockTemple.name=Temple Block
+tile.templeblock.name=Temple Block
 
 #Temple Mossy
-chisel.tile.blockTempleMossy.name=Mossy Temple Block
+tile.mossy_templeblock.name=Mossy Temple Block
 
 #Cloud
-chisel.tile.blockCloud.name=Cloud
+tile.cloud.name=Cloud
 
 #Stained glass T.T
-chisel.tile.chisel.stainedGlassWhite.name=Stained Glass
-chisel.tile.chisel.stainedGlassOrange.name=Stained Glass
-chisel.tile.chisel.stainedGlassMagenta.name=Stained Glass
-chisel.tile.chisel.stainedGlassLightBlue.name=Stained Glass
-chisel.tile.chisel.stainedGlassYellow.name=Stained Glass
-chisel.tile.chisel.stainedGlassLime.name=Stained Glass
-chisel.tile.chisel.stainedGlassPink.name=Stained Glass
-chisel.tile.chisel.stainedGlassGray.name=Stained Glass
-chisel.tile.chisel.stainedGlassLightGray.name=Stained Glass
-chisel.tile.chisel.stainedGlassCyan.name=Stained Glass
-chisel.tile.chisel.stainedGlassPurple.name=Stained Glass
-chisel.tile.chisel.stainedGlassBlue.name=Stained Glass
-chisel.tile.chisel.stainedGlassBrown.name=Stained Glass
-chisel.tile.chisel.stainedGlassGreen.name=Stained Glass
-chisel.tile.chisel.stainedGlassRed.name=Stained Glass
-chisel.tile.chisel.stainedGlassBlack.name=Stained Glass
+tile.stained_glass_white.name=Stained Glass
+tile.stained_glass_orange.name=Stained Glass
+tile.stained_glass_magenta.name=Stained Glass
+tile.stained_glass_lightBlue.name=Stained Glass
+tile.stained_glass_yellow.name=Stained Glass
+tile.stained_glass_lime.name=Stained Glass
+tile.stained_glass_pink.name=Stained Glass
+tile.stained_glass_gray.name=Stained Glass
+tile.stained_glass_lightgray.name=Stained Glass
+tile.stained_glass_cyan.name=Stained Glass
+tile.stained_glass_purple.name=Stained Glass
+tile.stained_glass_blue.name=Stained Glass
+tile.stained_glass_brown.name=Stained Glass
+tile.stained_glass_green.name=Stained Glass
+tile.stained_glass_red.name=Stained Glass
+tile.stained_glass_black.name=Stained Glass
 
 #Stained GlassPane T.T
-chisel.tile.chisel.stainedGlassPaneWhite.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneOrange.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneMagenta.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneLightBlue.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneYellow.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneLime.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPanePink.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneGray.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneLightGray.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneCyan.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPanePurple.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneBlue.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneBrown.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneGreen.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneRed.name=Stained Glass Pane
-chisel.tile.chisel.stainedGlassPaneBlack.name=Stained Glass Pane
-
-#Concerete
-chisel.tile.concrete.name=Concrete
+tile.stained_glass_pane_white.name=Stained Glass Pane
+tile.stained_glass_pane_orange.name=Stained Glass Pane
+tile.stained_glass_pane_magenta.name=Stained Glass Pane
+tile.stained_glass_pane_lightBlue.name=Stained Glass Pane
+tile.stained_glass_pane_yellow.name=Stained Glass Pane
+tile.stained_glass_pane_lime.name=Stained Glass Pane
+tile.stained_glass_pane_pink.name=Stained Glass Pane
+tile.stained_glass_pane_gray.name=Stained Glass Pane
+tile.stained_glass_pane_lightgray.name=Stained Glass Pane
+tile.stained_glass_pane_cyan.name=Stained Glass Pane
+tile.stained_glass_pane_purple.name=Stained Glass Pane
+tile.stained_glass_pane_blue.name=Stained Glass Pane
+tile.stained_glass_pane_brown.name=Stained Glass Pane
+tile.stained_glass_pane_green.name=Stained Glass Pane
+tile.stained_glass_pane_red.name=Stained Glass Pane
+tile.stained_glass_pane_black.name=Stained Glass Pane
 
 #Fantasy block
-chisel.tile.blockFft.name=Fantasy Block
+tile.fantasyblock.name=Fantasy Block
 
 #Paperwall
-chisel.tile.blockPaperwall.name=Paperwall
+tile.paperwall.name=Paperwall
 chisel.tile.paperwall.0.desc=Boxed Paperwall
 chisel.tile.paperwall.1.desc=Middle Striked Paperwall
 chisel.tile.paperwall.2.desc=Crossed Paperwall
@@ -681,7 +675,7 @@ chisel.tile.paperwall.7.desc=Plain Paperwall
 chisel.tile.paperwall.8.desc=Door Shaped Paperwall
 
 #Woolen Clay
-chisel.tile.blockWoolenClay.name=Woolen Clay
+tile.woolen_clay.name=Woolen Clay
 chisel.tile.woolenClay.0.desc=White Woolen Clay
 chisel.tile.woolenClay.1.desc=Orange Woolen Clay
 chisel.tile.woolenClay.2.desc=Magenta Woolen Clay
@@ -700,7 +694,7 @@ chisel.tile.woolenClay.14.desc=Red Woolen Clay
 chisel.tile.woolenClay.15.desc=Black Woolen Clay
 
 #Laboratory Block
-chisel.tile.blockLaboratory.name=Laboratory Block
+tile.laboratoryblock.name=Laboratory Block
 chisel.tile.blockLaboratory.0.desc=Wall Panel
 chisel.tile.blockLaboratory.1.desc=Dotted Panel
 chisel.tile.blockLaboratory.2.desc=Enameled Wall

--- a/src/main/resources/assets/chisel/lang/ru_RU.lang
+++ b/src/main/resources/assets/chisel/lang/ru_RU.lang
@@ -9,7 +9,7 @@ item.cloudBottle.name=Облако в бутылке
 # Have fun! ~zombiepig333
 
 #Cobblestone Blocks
-chisel.tile.cobblestone.name=Булыжник
+tile.cobblestone.name=Булыжник
 chisel.tile.cobblestone.0.desc=Выровненные булыжниковые кирпичи
 chisel.tile.cobblestone.1.desc=Детализированные булыжниковые кирпичи
 chisel.tile.cobblestone.2.desc=Маленькие булыжниковые кирпичи
@@ -27,10 +27,10 @@ chisel.tile.cobblestone.13.desc=Булыжник со светлой панел�
 chisel.tile.cobblestone.14.desc=Булыжник с тёмной панелью
 
 #Sandstone Blocks
-chisel.tile.sandstone.name=Песчаник
+tile.sandstone.name=Песчаник
 
 #Marble Blocks
-chisel.tile.marble.name=Мрамор
+tile.marble.name=Мрамор
 chisel.tile.marble.0.desc=Необработанный мрамор
 chisel.tile.marble.1.desc=Мраморный кирпич
 chisel.tile.marble.2.desc=Классическая мраморная панель
@@ -49,7 +49,7 @@ chisel.tile.marble.14.desc=Красивые мраморные плитки
 chisel.tile.marble.15.desc=Мраморные блоки
 
 #Marble Slabs
-chisel.tile.marbleSlab.name=Мраморная плита
+tile.marble_slab.name=Мраморная плита
 chisel.tile.marbleSlab.0.desc=Необработанная мраморная плита
 chisel.tile.marbleSlab.1.desc=Плита из мраморного кирпича
 chisel.tile.marbleSlab.2.desc=Плита из классической мраморной панели
@@ -68,7 +68,7 @@ chisel.tile.marbleSlab.14.desc=Плита из красивого плиточн
 chisel.tile.marbleSlab.15.desc=Плита из мраморных блоков
 
 #Marble Pillars (old)
-chisel.tile.marblePillar.name=Мраморная колонна
+tile.marble_pillar.name=Мраморная колонна
 chisel.tile.marblePillarOld.0.desc=Мраморная колонна
 chisel.tile.marblePillarOld.1.desc=Капитель мраморной колонны
 chisel.tile.marblePillarOld.2.desc=Основание мраморной колонны
@@ -105,7 +105,7 @@ chisel.tile.marblePillar.14.desc=Резная капитель колонны
 chisel.tile.marblePillar.15.desc=Декоративная капитель колонны
 
 #Marble Slabs (old)
-chisel.tile.marblePillarSlab.name=Плита из мраморной колонны
+tile.marble_pillar_slab.name=Плита из мраморной колонны
 chisel.tile.marblePillarSlabOld.0.desc=Плита из мраморной колонны
 chisel.tile.marblePillarSlabOld.1.desc=Плита из капители мраморной колонны
 chisel.tile.marblePillarSlabOld.2.desc=Плита из основания мраморной колонны
@@ -144,14 +144,14 @@ chisel.tile.marblePillarSlab.15.desc=Плита из декоративной к
 #Marble Stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.marbleStairs.0.name=Мраморные ступеньки
-chisel.tile.marbleStairs.1.name=Мраморные ступеньки
-chisel.tile.marbleStairs.2.name=Мраморные ступеньки
-chisel.tile.marbleStairs.3.name=Мраморные ступеньки
-chisel.tile.marbleStairs.4.name=Мраморные ступеньки
-chisel.tile.marbleStairs.5.name=Мраморные ступеньки
-chisel.tile.marbleStairs.6.name=Мраморные ступеньки
-chisel.tile.marbleStairs.7.name=Мраморные ступеньки
+tile.marble_stairs.0.name=Мраморные ступеньки
+tile.marble_stairs.1.name=Мраморные ступеньки
+tile.marble_stairs.2.name=Мраморные ступеньки
+tile.marble_stairs.3.name=Мраморные ступеньки
+tile.marble_stairs.4.name=Мраморные ступеньки
+tile.marble_stairs.5.name=Мраморные ступеньки
+tile.marble_stairs.6.name=Мраморные ступеньки
+tile.marble_stairs.7.name=Мраморные ступеньки
 
 #These are bugged.... so sad :,(
 chisel.tile.marbleStairs.0.desc=Ступеньки из необработанного мрамора
@@ -172,7 +172,7 @@ chisel.tile.marbleStairs.14.desc=Ступеньки из красивого пл
 chisel.tile.marbleStairs.15.desc=Ступеньки из мраморных блоков
 
 #Limestone
-chisel.tile.limestone.name=Известняк
+tile.limestone.name=Известняк
 chisel.tile.limestone.0.desc=Известняк
 chisel.tile.limestone.1.desc=Маленькие известняковые плитки
 chisel.tile.limestone.2.desc=Французские известняковые плитки
@@ -191,7 +191,7 @@ chisel.tile.limestone.14.desc=Известняк со светлой панел�
 chisel.tile.limestone.15.desc=Известняк с тёмной панелью
 
 #Limestone Slabs
-chisel.tile.limestoneSlab.name=Известняковая плита
+tile.limestone_slab.name=Известняковая плита
 chisel.tile.limestoneSlab.0.desc=Известняковая плита
 chisel.tile.limestoneSlab.1.desc=Маленькая известняковая плиточная плита
 chisel.tile.limestoneSlab.2.desc=Французская известняковая плиточная плита
@@ -212,14 +212,14 @@ chisel.tile.limestoneSlab.15.desc=Известняковая плита с тё�
 #Limestone Stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.limestoneStairs.0.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.1.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.2.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.3.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.4.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.5.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.6.name=Известняковые ступеньки
-chisel.tile.limestoneStairs.7.name=Известняковые ступеньки
+tile.limestone_stairs.0.name=Известняковые ступеньки
+tile.limestone_stairs.1.name=Известняковые ступеньки
+tile.limestone_stairs.2.name=Известняковые ступеньки
+tile.limestone_stairs.3.name=Известняковые ступеньки
+tile.limestone_stairs.4.name=Известняковые ступеньки
+tile.limestone_stairs.5.name=Известняковые ступеньки
+tile.limestone_stairs.6.name=Известняковые ступеньки
+tile.limestone_stairs.7.name=Известняковые ступеньки
 
 #These are bugged.... so sad :,(
 chisel.tile.limestoneStairs.0.desc=Известняковые ступеньки
@@ -240,7 +240,7 @@ chisel.tile.limestoneStairs.14.desc=Известняковые ступеньк�
 chisel.tile.limestoneStairs.15.desc=Известняковые ступеньки с тёмной панелью
 
 #Factory Blocks
-chisel.tile.blockFactory.name=Фабричный блок
+tile.factoryblock.name=Фабричный блок
 chisel.tile.blockFactory.0.desc=Ржавая металлическая пластина с точечным покрытием
 chisel.tile.blockFactory.1.desc=Ржавая металлическая пластина
 chisel.tile.blockFactory.2.desc=Очень ржавая металлическая пластина
@@ -259,7 +259,7 @@ chisel.tile.blockFactory.14.desc=Ржавые металлические пла�
 chisel.tile.blockFactory.15.desc=Изношенная металлическая колонна
 
 #Diamond blocks
-chisel.tile.diamond.name=Алмазный блок
+tile.diamond_block.name=Алмазный блок
 chisel.tile.diamond.1.desc=Рельефный алмазный блок
 chisel.tile.diamond.2.desc=Алмазный блок с панелью
 chisel.tile.diamond.3.desc=Алмазные ячейки
@@ -274,12 +274,12 @@ chisel.tile.diamond.11.desc=Алмазный блок Зельда
 chisel.tile.diamond.12.desc=Алмазный блок с декоративным слоем
 
 #Snakestone
-chisel.tile.snakestoneSand.name=Песочный змеиный камень
-chisel.tile.snakestoneStone.name=Каменный змеиный камень
-chisel.tile.snakestoneObsidian.name=Обсидиановый змеиный камень
+tile.snakestoneSand.name=Песочный змеиный камень
+tile.snakestoneStone.name=Каменный змеиный камень
+tile.obsidianSnakestone.name=Обсидиановый змеиный камень
 
 #Glass blocks
-chisel.tile.glass.name=Стекло
+tile.glass.name=Стекло
 chisel.tile.glass.1.desc=Пузырчатое стекло
 chisel.tile.glass.2.desc=Китайское стекло
 chisel.tile.glass.3.desc=Японское(?) стекло
@@ -297,7 +297,7 @@ chisel.tile.glass.14.desc=Стекло с тонкой сеткой
 chisel.tile.glass.15.desc=Современный железный забор
 
 #Sandstone
-chisel.tile.sandstone.name=Песчаник
+tile.sandstone.name=Песчаник
 chisel.tile.sandstone.3.desc=Блеклый песчаник
 chisel.tile.sandstone.4.desc=Песчаная колонна
 chisel.tile.sandstone.5.desc=Капитель песчаной колонны
@@ -313,11 +313,11 @@ chisel.tile.sandstone.14.desc=Песчаная мозаика
 chisel.tile.sandstone.15.desc=Ячеистые песчаные плитки
 
 #Sandstone scribbles
-chisel.tile.sandstoneScribbles.name=Песчаник с каракулями
+tile.sandstone_scribbles.name=Песчаник с каракулями
 chisel.tile.sandstoneScribbles.desc=Песчаник с каракулями
 
 #Concrete
-chisel.tile.blockConcrete.name=Бетон
+tile.concrete.name=Бетон
 chisel.tile.blockConcrete.0.desc=Бетон
 chisel.tile.blockConcrete.1.desc=Бетонный блок
 chisel.tile.blockConcrete.2.desc=Бетонная плита
@@ -331,10 +331,10 @@ chisel.tile.blockConcrete.9.desc=Частично выветрившийся б�
 chisel.tile.blockConcrete.10.desc=Асфальт
 
 #Road Line
-chisel.tile.roadLine.name=Дорожные линии
+tile.roadLine.name=Дорожные линии
 
 #Iron Blocks
-chisel.tile.iron.name=Железный блок
+tile.iron_block.name=Железный блок
 chisel.tile.iron.1.desc=Большие железные слитки
 chisel.tile.iron.2.desc=Маленькие железные слитки
 chisel.tile.iron.3.desc=Железные шестерни
@@ -352,7 +352,7 @@ chisel.tile.iron.14.desc=Железные разрезы
 chisel.tile.iron.15.desc=Простой железный блок
 
 #Gold Blocks
-chisel.tile.gold.name=Золотой блок
+tile.gold_block.name=Золотой блок
 chisel.tile.gold.1.desc=Большие золотые слитки
 chisel.tile.gold.2.desc=Маленькие золотые слитки
 chisel.tile.gold.3.desc=Золотые кирпичи
@@ -369,7 +369,7 @@ chisel.tile.gold.13.desc=Золотая звезда в обсидиане
 chisel.tile.gold.14.desc=Простой золотой блок
 
 #Glowstone
-chisel.tile.lightstone.name=Светящийся камень
+tile.glowstone.name=Светящийся камень
 chisel.tile.lightstone.1.desc=Булыжниковый светящийся блок
 chisel.tile.lightstone.2.desc=Проржавевшие светящиеся блоки
 chisel.tile.lightstone.3.desc=Светящиеся блоки со стеклом
@@ -387,7 +387,7 @@ chisel.tile.lightstone.14.desc=Светящийся висмут
 chisel.tile.lightstone.15.desc=Панель из светящегося висмута
 
 #Lapis blocks
-chisel.tile.lapis.name=Лазуритовый блок
+tile.lapis_block.name=Лазуритовый блок
 chisel.tile.lapis.1.desc=Плотный лазуритовый блок
 chisel.tile.lapis.2.desc=Тёмный лазуритовый блок
 chisel.tile.lapis.3.desc=Лазуритовый блок Зельда
@@ -398,7 +398,7 @@ chisel.tile.lapis.7.desc=Гладкий лазурит
 chisel.tile.lapis.8.desc=Лазурит с декоративным слоем
 
 #Emerald Blocks
-chisel.tile.emerald.name=Изумрудный блок
+tile.emerald_block.name=Изумрудный блок
 chisel.tile.emerald.1.desc=Изумрудная панель
 chisel.tile.emerald.2.desc=Классическая изумрудная панель
 chisel.tile.emerald.3.desc=Гладкий изумруд
@@ -412,7 +412,7 @@ chisel.tile.emerald.10.desc=Маленькие декоративные изум
 chisel.tile.emerald.11.desc=Декоративные изумрудные блоки
 
 #Nether Brick
-chisel.tile.netherBrick.name=Кирпич Нижнего мира
+tile.nether_brick.name=Кирпич Нижнего мира
 chisel.tile.netherBrick.1.desc=Синий кирпич Нижнего мира
 chisel.tile.netherBrick.2.desc=Забрызганный кирпич Нижнего мира
 chisel.tile.netherBrick.3.desc=Кирпич Нижнего мира, сделанный из внутренностей
@@ -430,7 +430,7 @@ chisel.tile.netherBrick.14.desc=Красный кирпич Нижнего ми�
 chisel.tile.netherBrick.15.desc=Маленький красный кирпич Нижнего мира
 
 #Netherrack
-chisel.tile.hellrock.name=Камень Нижнего мира
+tile.netherrack.name=Камень Нижнего мира
 chisel.tile.hellrock.1.desc=Гравий Нижнего мира с кровью
 chisel.tile.hellrock.2.desc=Камень Нижнего мира с кровью
 chisel.tile.hellrock.3.desc=Тёмный камень Нижнего мира с кровью
@@ -447,7 +447,7 @@ chisel.tile.hellrock.13.desc=Тёмный красный камень Нижне
 chisel.tile.hellrock.14.desc=Камень Нижнего мира с текучей лавой
 
 #Mossy Stone
-chisel.tile.stoneMoss.name=Замшелый булыжник
+tile.mossy_cobblestone.name=Замшелый булыжник
 chisel.tile.stoneMoss.1.desc=Выровненные замшелые булыжниковые кирпичи
 chisel.tile.stoneMoss.2.desc=Детализированные замшелые булыжниковые кирпичи
 chisel.tile.stoneMoss.3.desc=Маленькие замшелые булыжниковые кирпичи
@@ -465,7 +465,7 @@ chisel.tile.stoneMoss.14.desc=Замшелый булыжник со светл�
 chisel.tile.stoneMoss.15.desc=Замшелый булыжник с тёмной панелью
 
 #Stone Bricks
-chisel.tile.stoneBrick.name=Каменный кирпич
+tile.stonebrick.name=Каменный кирпич
 chisel.tile.stoneBrick.4.desc=Маленькие каменные кирпичи
 chisel.tile.stoneBrick.5.desc=Широкие каменные кирпичи
 chisel.tile.stoneBrick.6.desc=Маленькие неупорядоченные каменные кирпичи
@@ -480,7 +480,7 @@ chisel.tile.stoneBrick.14.desc=Декоративная каменная пан�
 chisel.tile.stoneBrick.15.desc=Ядовитый каменный кирпич
 
 #Dirt
-chisel.tile.blockDirt.name=Земля
+tile.dirt.name=Земля
 chisel.tile.blockDirt.0.desc=Беспорядочные земляные кирпичи
 chisel.tile.blockDirt.1.desc=Земляные кирпичи, похожи на кирпичи Нижнего мира
 chisel.tile.blockDirt.2.desc=Земляные кирпичи
@@ -496,7 +496,7 @@ chisel.tile.blockDirt.11.desc=Земляные слои
 chisel.tile.blockDirt.12.desc=Разрушенная земля
 
 #Ice
-chisel.tile.ice.name=Лёд
+tile.ice.name=Лёд
 chisel.tile.ice.1.desc=Необработанный ледяной блок
 chisel.tile.ice.2.desc=Булыжниковый лёд
 chisel.tile.ice.3.desc=Большие необработанные ледяные кирпичи
@@ -514,7 +514,7 @@ chisel.tile.ice.14.desc=Блок ледяного висмута
 chisel.tile.ice.15.desc=Блок ледяного яда
 
 #Ice Pillars
-chisel.tile.icePillar.name=Ледяная колонна
+tile.ice_pillar.name=Ледяная колонна
 chisel.tile.icePillar.0.desc=Ледяная колонна
 chisel.tile.icePillar.1.desc=Капитель ледяной колонны
 chisel.tile.icePillar.2.desc=Основание ледяной колонны
@@ -533,15 +533,15 @@ chisel.tile.icePillar.14.desc=Декоративное основание гре
 chisel.tile.icePillar.15.desc=Декоративное основание обычной ледяной колонны
 
 #Ice Stairs
-chisel.tile.iceStairs.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.0.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.1.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.2.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.3.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.4.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.5.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.6.name=Ледяные ступеньки
-chisel.tile.chisel.iceStairs.7.name=Ледяные ступеньки
+tile.ice_stairs.name=Ледяные ступеньки
+tile.ice_stairs.0.name=Ледяные ступеньки
+tile.ice_stairs.1.name=Ледяные ступеньки
+tile.ice_stairs.2.name=Ледяные ступеньки
+tile.ice_stairs.3.name=Ледяные ступеньки
+tile.ice_stairs.4.name=Ледяные ступеньки
+tile.ice_stairs.5.name=Ледяные ступеньки
+tile.ice_stairs.6.name=Ледяные ступеньки
+tile.ice_stairs.7.name=Ледяные ступеньки
 chisel.tile.iceStairs.0.desc=Ледяные ступеньки
 chisel.tile.iceStairs.1.desc=Необработанные ледяные ступеньки
 chisel.tile.iceStairs.2.desc=Булыжниковые ледяные ступеньки
@@ -560,7 +560,7 @@ chisel.tile.iceStairs.14.desc=Ступеньки из ледяного висм�
 chisel.tile.iceStairs.15.desc=Ступеньки из ледяного яда
 
 #Obsidian
-chisel.tile.obsidian.name=Обсидиан
+tile.obsidian.name=Обсидиан
 chisel.tile.obsidian.1.desc=Большая обсидиановая колонна
 chisel.tile.obsidian.2.desc=Обсидиановая колонна
 chisel.tile.obsidian.3.desc=Резной обсидиан
@@ -578,98 +578,92 @@ chisel.tile.obsidian.14.desc=Светлые обсидиановые блоки 
 chisel.tile.obsidian.15.desc=Маленькие обсидиановые блоки в дубовом ящике
 
 #Wood
-chisel.tile.wood-oak.name=Дубовая древесина
-chisel.tile.wood-birch.name=Берёзовая древесина
-chisel.tile.wood-spruce.name=Еловая древесина
-chisel.tile.wood-jungle.name=Тропическая древесина
-chisel.tile.wood-dark-oak.name=Древесина тёмного дуба
-chisel.tile.wood-acacia.name=Древесина акации
+tile.oak_planks.name=Дубовая древесина
+tile.birch_planks.name=Берёзовая древесина
+tile.spruce_planks.name=Еловая древесина
+tile.jungle_planks.name=Тропическая древесина
+tile.dark_oak_planks.name=Древесина тёмного дуба
+tile.acacia_planks.name=Древесина акации
 
 #Remember to do the descriptions.
 
-#Obsidian Snakestone
-chisel.tile.obsidianSnakestone.name=Обсидиановый змеиный камень
-
 #Iron Fence
-chisel.tile.fenceIron=Железные прутья
+tile.iron_bars.name=Железные прутья
 
 #Glass Panes
-chisel.tile.glassPane=Стеклянная панель
+tile.glass_pane.name=Стеклянная панель
 
 #Redstone block
-chisel.tile.blockRedstone.name=Красный блок
+tile.redstone_block.name=Красный блок
 
 #Holystone
-chisel.tile.blockHolystone.name=Пемза
+tile.holystone.name=Пемза
 
 #Lavastone
-chisel.tile.blockLavastone.name=Лавовый камень
+tile.lavastone.name=Лавовый камень
 
 #Carpet
-chisel.tile.blockCarpet.name=Ковёр
+tile.carpet_block.name=Ковёр
 
 #Carpet floor
-chisel.tile.blockCarpetFloor.name=Напольный ковёр
+tile.carpet.name=Напольный ковёр
 
 #Bookshelf
-chisel.tile.blockBookshelf.name=Книжный шкаф
+tile.bookshelf.name=Книжный шкаф
 
 #Tyrian
-chisel.tile.blockTyrian.name=Тириан
+tile.tyrian.name=Тириан
 
 #Temple
-chisel.tile.blockTemple.name=Блок храма
+tile.templeblock.name=Блок храма
 
 #Temple Mossy
-chisel.tile.blockTempleMossy.name=Замшелый блок храма
+tile.mossy_templeblock.name=Замшелый блок храма
 
 #Cloud
-chisel.tile.blockCloud.name=Облако
+tile.cloud.name=Облако
 
 #Stained glass T.T
-chisel.tile.chisel.stainedGlassWhite.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassOrange.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassMagenta.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassLightBlue.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassYellow.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassLime.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassPink.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassGray.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassLightGray.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassCyan.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassPurple.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassBlue.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassBrown.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassGreen.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassRed.name=Окрашенное стекло
-chisel.tile.chisel.stainedGlassBlack.name=Окрашенное стекло
+tile.stained_glass_white.name=Окрашенное стекло
+tile.stained_glass_orange.name=Окрашенное стекло
+tile.stained_glass_magenta.name=Окрашенное стекло
+tile.stained_glass_lightBlue.name=Окрашенное стекло
+tile.stained_glass_yellow.name=Окрашенное стекло
+tile.stained_glass_lime.name=Окрашенное стекло
+tile.stained_glass_pink.name=Окрашенное стекло
+tile.stained_glass_gray.name=Окрашенное стекло
+tile.stained_glass_lightgray.name=Окрашенное стекло
+tile.stained_glass_cyan.name=Окрашенное стекло
+tile.stained_glass_purple.name=Окрашенное стекло
+tile.stained_glass_blue.name=Окрашенное стекло
+tile.stained_glass_brown.name=Окрашенное стекло
+tile.stained_glass_green.name=Окрашенное стекло
+tile.stained_glass_red.name=Окрашенное стекло
+tile.stained_glass_black.name=Окрашенное стекло
 
 #Stained GlassPane T.T
-chisel.tile.chisel.stainedGlassPaneWhite.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneOrange.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneMagenta.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneLightBlue.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneYellow.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneLime.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPanePink.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneGray.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneLightGray.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneCyan.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPanePurple.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneBlue.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneBrown.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneGreen.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneRed.name=Окрашенная стеклянная панель
-chisel.tile.chisel.stainedGlassPaneBlack.name=Окрашенная стеклянная панель
-
-#Concerete
-chisel.tile.concrete.name=Бетон
+tile.stained_glass_pane_white.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_orange.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_magenta.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_lightBlue.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_yellow.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_lime.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_pink.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_gray.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_lightgray.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_cyan.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_purple.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_blue.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_brown.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_green.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_red.name=Окрашенная стеклянная панель
+tile.stained_glass_pane_black.name=Окрашенная стеклянная панель
 
 #Fantasy block
-chisel.tile.blockFft.name=Фантастический блок
+tile.fantasyblock.name=Фантастический блок
 
 #Paperwall
-chisel.tile.blockPaperwall.name=Бумажная стена
+tile.paperwall.name=Бумажная стена
 chisel.tile.paperwall.0.desc=Коробочная бумажная стена
 chisel.tile.paperwall.1.desc=Разделённая бумажная стена
 chisel.tile.paperwall.2.desc=Скрещенная бумажная стена
@@ -681,7 +675,7 @@ chisel.tile.paperwall.7.desc=Обычная бумажная стена
 chisel.tile.paperwall.8.desc=Двереобразная бумажная стена
 
 #Woolen Clay
-chisel.tile.blockWoolenClay.name=Шерстяная глина
+tile.woolen_clay.name=Шерстяная глина
 chisel.tile.woolenClay.0.desc=Белая шерстяная глина
 chisel.tile.woolenClay.1.desc=Оранжевая шерстяная глина
 chisel.tile.woolenClay.2.desc=Сиреневая шерстяная глина

--- a/src/main/resources/assets/chisel/lang/zh_CN.lang
+++ b/src/main/resources/assets/chisel/lang/zh_CN.lang
@@ -9,7 +9,7 @@ item.cloudBottle.name=瓶装云朵
 # Have fun! ~zombiepig333
 
 #Cobblestone Blocks
-chisel.tile.cobblestone.name=圆石
+tile.cobblestone.name=圆石
 chisel.tile.cobblestone.0.desc=圆石砖
 chisel.tile.cobblestone.1.desc=精致錾制圆石砖
 chisel.tile.cobblestone.2.desc=小块錾制圆石砖
@@ -27,10 +27,10 @@ chisel.tile.cobblestone.13.desc=白色的镶板圆石砖
 chisel.tile.cobblestone.14.desc=深色的镶板圆石砖
 
 #Sandstone Blocks
-chisel.tile.sandstone.name=沙石
+tile.sandstone.name=沙石
 
 #Marble Blocks
-chisel.tile.marble.name=大理石
+tile.marble.name=大理石
 chisel.tile.marble.0.desc=天然大理石
 chisel.tile.marble.1.desc=大理石砖
 chisel.tile.marble.2.desc=古典的镶板大理石
@@ -48,8 +48,8 @@ chisel.tile.marble.13.desc=整齐錾制的石瓷砖
 chisel.tile.marble.14.desc=花式錾制的石瓷砖
 chisel.tile.marble.15.desc=大理石方砖
 
-#Marble Slabs
-chisel.tile.marbleSlab.name=大理石台阶
+#Marble slabs
+tile.marble_slab.name=大理石台阶
 chisel.tile.marbleSlab.0.desc=天然大理石台阶
 chisel.tile.marbleSlab.1.desc=大理石砖台阶
 chisel.tile.marbleSlab.2.desc=古典镶板大理石台阶
@@ -68,7 +68,7 @@ chisel.tile.marbleSlab.14.desc=花式錾制石瓷砖台阶
 chisel.tile.marbleSlab.15.desc=大理石方砖台阶
 
 #Marble Pillars (新版已移除)
-chisel.tile.marblePillar.name=Marble Pillar
+tile.marble_pillar.name=Marble Pillar
 chisel.tile.marblePillarOld.0.desc=Marble Pillar
 chisel.tile.marblePillarOld.1.desc=Marble Pillar Capstone
 chisel.tile.marblePillarOld.2.desc=Marble Pillar Base
@@ -104,26 +104,26 @@ chisel.tile.marblePillar.13.desc=简朴的柱顶石 & 宽竖纹石柱
 chisel.tile.marblePillar.14.desc=精致錾制的柱顶石
 chisel.tile.marblePillar.15.desc=漂亮的柱顶石
 
-#Marble Slabs (新版已移除)
-chisel.tile.marblePillarSlab.name=Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.0.desc=Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.1.desc=Marble Pllar Capstone Slab
-chisel.tile.marblePillarSlabOld.2.desc=Marble Pillar Base Slab
-chisel.tile.marblePillarSlabOld.3.desc=Small Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.4.desc=Carved Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.5.desc=Ornamental Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.6.desc=Greek Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.7.desc=Plain Marble Pillar Slab
-chisel.tile.marblePillarSlabOld.8.desc=Greek Marble Pillar capstone Slab
-chisel.tile.marblePillarSlabOld.9.desc=Plain Marble Pillar capstone Slab
-chisel.tile.marblePillarSlabOld.10.desc=Greek Marble Pillar Base Slab
-chisel.tile.marblePillarSlabOld.11.desc=Plain Marble Pillar Base Slab
-chisel.tile.marblePillarSlabOld.12.desc=Greek Marble Pillar ornate capstone Slab
-chisel.tile.marblePillarSlabOld.13.desc=Plain Marble Pillar ornate capstone Slab
-chisel.tile.marblePillarSlabOld.14.desc=Greek Marble Pillar ornate Base Slab
-chisel.tile.marblePillarSlabOld.15.desc=Plain Marble Pillar ornate Base Slab
+#Marble slabs (新版已移除)
+tile.marble_pillar_slab.name=Marble Pillar slab
+chisel.tile.marblePillarslabOld.0.desc=Marble Pillar Slab
+chisel.tile.marblePillarslabOld.1.desc=Marble Pllar Capstone Slab
+chisel.tile.marblePillarslabOld.2.desc=Marble Pillar Base Slab
+chisel.tile.marblePillarslabOld.3.desc=Small Marble Pillar Slab
+chisel.tile.marblePillarslabOld.4.desc=Carved Marble Pillar Slab
+chisel.tile.marblePillarslabOld.5.desc=Ornamental Marble Pillar Slab
+chisel.tile.marblePillarslabOld.6.desc=Greek Marble Pillar Slab
+chisel.tile.marblePillarslabOld.7.desc=Plain Marble Pillar Slab
+chisel.tile.marblePillarslabOld.8.desc=Greek Marble Pillar capstone Slab
+chisel.tile.marblePillarslabOld.9.desc=Plain Marble Pillar capstone Slab
+chisel.tile.marblePillarslabOld.10.desc=Greek Marble Pillar Base Slab
+chisel.tile.marblePillarslabOld.11.desc=Plain Marble Pillar Base Slab
+chisel.tile.marblePillarslabOld.12.desc=Greek Marble Pillar ornate capstone Slab
+chisel.tile.marblePillarslabOld.13.desc=Plain Marble Pillar ornate capstone Slab
+chisel.tile.marblePillarslabOld.14.desc=Greek Marble Pillar ornate Base Slab
+chisel.tile.marblePillarslabOld.15.desc=Plain Marble Pillar ornate Base Slab
 
-#Marble Slabs (current)
+#Marble slabs (current)
 chisel.tile.marblePillarSlab.0.desc=大理石柱台阶
 chisel.tile.marblePillarSlab.1.desc=原始石柱台阶
 chisel.tile.marblePillarSlab.2.desc=简单錾制的石柱台阶
@@ -141,17 +141,17 @@ chisel.tile.marblePillarSlab.13.desc=简朴的柱顶石 & 宽竖纹石柱台阶
 chisel.tile.marblePillarSlab.14.desc=精致錾制的柱顶石台阶
 chisel.tile.marblePillarSlab.15.desc=漂亮的柱顶石台阶
 
-#Marble Stairs
+#Marble stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.marbleStairs.0.name=大理石楼梯
-chisel.tile.marbleStairs.1.name=大理石楼梯
-chisel.tile.marbleStairs.2.name=大理石楼梯
-chisel.tile.marbleStairs.3.name=大理石楼梯
-chisel.tile.marbleStairs.4.name=大理石楼梯
-chisel.tile.marbleStairs.5.name=大理石楼梯
-chisel.tile.marbleStairs.6.name=大理石楼梯
-chisel.tile.marbleStairs.7.name=大理石楼梯
+tile.marble_stairs.0.name=大理石楼梯
+tile.marble_stairs.1.name=大理石楼梯
+tile.marble_stairs.2.name=大理石楼梯
+tile.marble_stairs.3.name=大理石楼梯
+tile.marble_stairs.4.name=大理石楼梯
+tile.marble_stairs.5.name=大理石楼梯
+tile.marble_stairs.6.name=大理石楼梯
+tile.marble_stairs.7.name=大理石楼梯
 
 #These are bugged.... so sad :,(
 chisel.tile.marbleStairs.0.desc=天然大理石楼梯
@@ -172,7 +172,7 @@ chisel.tile.marbleStairs.14.desc=花式錾制石瓷砖楼梯
 chisel.tile.marbleStairs.15.desc=大理石方砖楼梯
 
 #Limestone
-chisel.tile.limestone.name=石灰岩
+tile.limestone.name=石灰岩
 chisel.tile.limestone.0.desc=石灰岩
 chisel.tile.limestone.1.desc=小块錾制灰岩瓷砖
 chisel.tile.limestone.2.desc=法式灰岩瓷砖
@@ -190,8 +190,8 @@ chisel.tile.limestone.13.desc=大块錾制灰岩
 chisel.tile.limestone.14.desc=亮色镶板灰岩
 chisel.tile.limestone.15.desc=暗色镶板灰岩
 
-#Limestone Slabs
-chisel.tile.limestoneSlab.name=石灰岩台阶
+#Limestone slabs
+tile.limestone_slab.name=石灰岩台阶
 chisel.tile.limestoneSlab.0.desc=石灰岩台阶
 chisel.tile.limestoneSlab.1.desc=小块錾制灰岩瓷砖台阶
 chisel.tile.limestoneSlab.2.desc=法式灰岩瓷砖台阶
@@ -209,17 +209,17 @@ chisel.tile.limestoneSlab.13.desc=大块錾制灰岩台阶
 chisel.tile.limestoneSlab.14.desc=亮色镶板灰岩台阶
 chisel.tile.limestoneSlab.15.desc=暗色镶板灰岩台阶
 
-#Limestone Stairs
+#Limestone stairs
 #The same name goes here 8 different times since stairs take up 8 block positions.
 #Sorry!  It was the only way!
-chisel.tile.limestoneStairs.0.name=石灰岩楼梯
-chisel.tile.limestoneStairs.1.name=石灰岩楼梯
-chisel.tile.limestoneStairs.2.name=石灰岩楼梯
-chisel.tile.limestoneStairs.3.name=石灰岩楼梯
-chisel.tile.limestoneStairs.4.name=石灰岩楼梯
-chisel.tile.limestoneStairs.5.name=石灰岩楼梯
-chisel.tile.limestoneStairs.6.name=石灰岩楼梯
-chisel.tile.limestoneStairs.7.name=石灰岩楼梯
+tile.limestone_stairs.0.name=石灰岩楼梯
+tile.limestone_stairs.1.name=石灰岩楼梯
+tile.limestone_stairs.2.name=石灰岩楼梯
+tile.limestone_stairs.3.name=石灰岩楼梯
+tile.limestone_stairs.4.name=石灰岩楼梯
+tile.limestone_stairs.5.name=石灰岩楼梯
+tile.limestone_stairs.6.name=石灰岩楼梯
+tile.limestone_stairs.7.name=石灰岩楼梯
 
 #These are bugged.... so sad :,(
 chisel.tile.limestoneStairs.0.desc=石灰岩楼梯
@@ -240,7 +240,7 @@ chisel.tile.limestoneStairs.14.desc=亮色镶板灰岩楼梯
 chisel.tile.limestoneStairs.15.desc=暗色镶板灰岩楼梯
 
 #Factory Blocks
-chisel.tile.blockFactory.name=工厂方块
+tile.factoryblock.name=工厂方块
 chisel.tile.blockFactory.0.desc=生锈的金属板 & 点状图案
 chisel.tile.blockFactory.1.desc=生锈的金属板
 chisel.tile.blockFactory.2.desc=年久失修的金属板
@@ -259,7 +259,7 @@ chisel.tile.blockFactory.14.desc=生锈的金属板
 chisel.tile.blockFactory.15.desc=磨损的金属外壳
 
 #Diamond blocks
-chisel.tile.diamond.name=钻石块
+tile.diamond_block.name=钻石块
 chisel.tile.diamond.1.desc=有光泽的钻石块
 chisel.tile.diamond.2.desc=镶板的钻石块
 chisel.tile.diamond.3.desc=有细胞图案的钻石块
@@ -274,12 +274,12 @@ chisel.tile.diamond.11.desc=塞尔达钻石块
 chisel.tile.diamond.12.desc=镶金框的钻石块
 
 #Snakestone
-chisel.tile.snakestoneSand.name=蛇沙石
-chisel.tile.snakestoneStone.name=蛇石
-chisel.tile.snakestoneObsidian.name=黑曜蛇石
+tile.snakestoneSand.name=蛇沙石
+tile.snakestoneStone.name=蛇石
+tile.obsidianSnakestone.name=黑曜蛇石
 
 #Glass blocks
-chisel.tile.glass.name=玻璃
+tile.glass.name=玻璃
 chisel.tile.glass.1.desc=透明圆形玻璃
 chisel.tile.glass.2.desc=中国式窗棂
 chisel.tile.glass.3.desc=日本式窗格
@@ -297,7 +297,7 @@ chisel.tile.glass.14.desc=细格栅玻璃
 chisel.tile.glass.15.desc=现代式铁栅栏
 
 #Sandstone
-chisel.tile.sandstone.name=沙石
+tile.sandstone.name=沙石
 chisel.tile.sandstone.3.desc=褪色沙石
 chisel.tile.sandstone.4.desc=沙石柱
 chisel.tile.sandstone.5.desc=沙石柱顶石
@@ -313,11 +313,11 @@ chisel.tile.sandstone.14.desc=镶嵌錾制沙石
 chisel.tile.sandstone.15.desc=层叠錾制沙石
 
 #Sandstone scribbles
-chisel.tile.sandstoneScribbles.name=刻文沙石
+tile.sandstone_scribbles.name=刻文沙石
 chisel.tile.sandstoneScribbles.desc=刻文沙石
 
 #Concrete
-chisel.tile.blockConcrete.name=混凝土
+tile.concrete.name=混凝土
 chisel.tile.blockConcrete.0.desc=混凝土
 chisel.tile.blockConcrete.1.desc=混凝土方块
 chisel.tile.blockConcrete.2.desc=双层混凝土台阶
@@ -331,10 +331,10 @@ chisel.tile.blockConcrete.9.desc=局部风化的混凝土方块
 chisel.tile.blockConcrete.10.desc=沥青
 
 #Road Line
-chisel.tile.roadLine.name=道路标线
+tile.roadLine.name=道路标线
 
 #Iron Blocks
-chisel.tile.iron.name=铁块
+tile.iron_block.name=铁块
 chisel.tile.iron.1.desc=大块铁锭
 chisel.tile.iron.2.desc=小块铁锭
 chisel.tile.iron.3.desc=铁齿轮
@@ -352,7 +352,7 @@ chisel.tile.iron.14.desc=通风口
 chisel.tile.iron.15.desc=普通的铁块
 
 #Gold Blocks
-chisel.tile.gold.name=金块
+tile.gold_block.name=金块
 chisel.tile.gold.1.desc=大块金块
 chisel.tile.gold.2.desc=小块金块
 chisel.tile.gold.3.desc=金砖
@@ -369,7 +369,7 @@ chisel.tile.gold.13.desc=有金月亮图案的黑曜石
 chisel.tile.gold.14.desc=普通的金块
 
 #Glowstone
-chisel.tile.lightstone.name=萤石
+tile.glowstone.name=萤石
 chisel.tile.lightstone.1.desc=圆石状萤石
 chisel.tile.lightstone.2.desc=被腐蚀的萤石砖
 chisel.tile.lightstone.3.desc=有玻璃的萤石砖
@@ -387,7 +387,7 @@ chisel.tile.lightstone.14.desc=铋合金萤石
 chisel.tile.lightstone.15.desc=铋合金镶板萤石
 
 #Lapis blocks
-chisel.tile.lapis.name=青金石块
+tile.lapis_block.name=青金石块
 chisel.tile.lapis.1.desc=厚实的青金石块
 chisel.tile.lapis.2.desc=暗色青金石块
 chisel.tile.lapis.3.desc=塞尔达青金石块
@@ -398,7 +398,7 @@ chisel.tile.lapis.7.desc=光滑的青金石块
 chisel.tile.lapis.8.desc=镶金框的青金石块
 
 #Emerald Blocks
-chisel.tile.emerald.name=绿宝石块
+tile.emerald_block.name=绿宝石块
 chisel.tile.emerald.1.desc=整面錾制绿宝石块
 chisel.tile.emerald.2.desc=经典镶板绿宝石块
 chisel.tile.emerald.3.desc=光滑的绿宝石块
@@ -412,7 +412,7 @@ chisel.tile.emerald.10.desc=精致的小块錾制绿宝石块
 chisel.tile.emerald.11.desc=精致的绿宝石块
 
 #Nether Brick
-chisel.tile.netherBrick.name=地狱砖
+tile.nether_brick.name=地狱砖
 chisel.tile.netherBrick.1.desc=蓝色地狱砖
 chisel.tile.netherBrick.2.desc=污秽的地狱砖
 chisel.tile.netherBrick.3.desc=用内脏砌成的地狱砖
@@ -430,7 +430,7 @@ chisel.tile.netherBrick.14.desc=红色地狱砖
 chisel.tile.netherBrick.15.desc=小块錾制红色地狱砖
 
 #Netherrack
-chisel.tile.hellrock.name=地狱岩
+tile.netherrack.name=地狱岩
 chisel.tile.hellrock.1.desc=沾有血迹的下界砂砾
 chisel.tile.hellrock.2.desc=沾有血迹的地狱岩
 chisel.tile.hellrock.3.desc=沾有血迹的暗色下界砂砾
@@ -447,7 +447,7 @@ chisel.tile.hellrock.13.desc=深红色地狱岩
 chisel.tile.hellrock.14.desc=流着岩浆的地狱岩
 
 #Mossy Stone
-chisel.tile.stoneMoss.name=苔石
+tile.mossy_cobblestone.name=苔石
 chisel.tile.stoneMoss.1.desc=整齐錾制苔石砖
 chisel.tile.stoneMoss.2.desc=精致錾制苔石砖
 chisel.tile.stoneMoss.3.desc=小块錾制苔石砖
@@ -465,7 +465,7 @@ chisel.tile.stoneMoss.14.desc=亮色镶板苔石瓷砖
 chisel.tile.stoneMoss.15.desc=暗色镶板苔石瓷砖
 
 #Stone Bricks
-chisel.tile.stoneBrick.name=石砖
+tile.stonebrick.name=石砖
 chisel.tile.stoneBrick.4.desc=小块錾制石砖
 chisel.tile.stoneBrick.5.desc=大块錾制石砖
 chisel.tile.stoneBrick.6.desc=小杂石砖
@@ -480,7 +480,7 @@ chisel.tile.stoneBrick.14.desc=精致的镶板石砖
 chisel.tile.stoneBrick.15.desc=罪恶的石砖
 
 #Dirt
-chisel.tile.blockDirt.name=泥土
+tile.dirt.name=泥土
 chisel.tile.blockDirt.0.desc=杂乱堆叠的泥砖
 chisel.tile.blockDirt.1.desc=模仿地狱砖设计的泥砖
 chisel.tile.blockDirt.2.desc=泥砖
@@ -496,7 +496,7 @@ chisel.tile.blockDirt.11.desc=页状泥土
 chisel.tile.blockDirt.12.desc=破碎的泥土
 
 #Ice
-chisel.tile.ice.name=冰
+tile.ice.name=冰
 chisel.tile.ice.1.desc=粗糙錾制的冰砖
 chisel.tile.ice.2.desc=圆石状冰
 chisel.tile.ice.3.desc=大块粗糙錾制的冰砖
@@ -514,7 +514,7 @@ chisel.tile.ice.14.desc=铋合金冰块
 chisel.tile.ice.15.desc=罪恶的冰块
 
 #Ice Pillars
-chisel.tile.icePillar.name=冰柱
+tile.ice_pillar.name=冰柱
 chisel.tile.icePillar.0.desc=冰柱
 chisel.tile.icePillar.1.desc=冰柱顶块
 chisel.tile.icePillar.2.desc=冰柱基座
@@ -532,16 +532,16 @@ chisel.tile.icePillar.13.desc=简朴的冰柱 & 精致的柱顶块
 chisel.tile.icePillar.14.desc=希腊式冰柱 & 精致的柱基座
 chisel.tile.icePillar.15.desc=简朴的冰柱 & 精致的柱基座
 
-#Ice Stairs
-chisel.tile.iceStairs.name=冰楼梯
-chisel.tile.chisel.iceStairs.0.name=冰楼梯
-chisel.tile.chisel.iceStairs.1.name=冰楼梯
-chisel.tile.chisel.iceStairs.2.name=冰楼梯
-chisel.tile.chisel.iceStairs.3.name=冰楼梯
-chisel.tile.chisel.iceStairs.4.name=冰楼梯
-chisel.tile.chisel.iceStairs.5.name=冰楼梯
-chisel.tile.chisel.iceStairs.6.name=冰楼梯
-chisel.tile.chisel.iceStairs.7.name=冰楼梯
+#Ice stairs
+tile.ice_stairs.name=冰楼梯
+tile.ice_stairs.0.name=冰楼梯
+tile.ice_stairs.1.name=冰楼梯
+tile.ice_stairs.2.name=冰楼梯
+tile.ice_stairs.3.name=冰楼梯
+tile.ice_stairs.4.name=冰楼梯
+tile.ice_stairs.5.name=冰楼梯
+tile.ice_stairs.6.name=冰楼梯
+tile.ice_stairs.7.name=冰楼梯
 chisel.tile.iceStairs.0.desc=冰楼梯
 chisel.tile.iceStairs.1.desc=粗糙錾制的楼梯
 chisel.tile.iceStairs.2.desc=圆石状楼梯
@@ -560,7 +560,7 @@ chisel.tile.iceStairs.14.desc=铋合金冰楼梯
 chisel.tile.iceStairs.15.desc=罪恶的冰楼梯
 
 #Obsidian
-chisel.tile.obsidian.name=黑曜石
+tile.obsidian.name=黑曜石
 chisel.tile.obsidian.1.desc=大块錾制的黑曜石柱
 chisel.tile.obsidian.2.desc=黑曜石柱
 chisel.tile.obsidian.3.desc=錾制黑曜石柱
@@ -578,98 +578,92 @@ chisel.tile.obsidian.14.desc=有希腊装饰图案的亮色黑曜石
 chisel.tile.obsidian.15.desc=装在板条箱中的小块錾制黑曜石
 
 #Wood
-chisel.tile.wood-oak.name=橡木
-chisel.tile.wood-birch.name=白桦木
-chisel.tile.wood-spruce.name=云杉木
-chisel.tile.wood-jungle.name=从林木
-chisel.tile.wood-dark-oak.name=深色橡木
-chisel.tile.wood-acacia.name=金合欢木
+tile.oak_planks.name=橡木
+tile.birch_planks.name=白桦木
+tile.spruce_planks.name=云杉木
+tile.jungle_planks.name=从林木
+tile.dark_oak_planks.name=深色橡木
+tile.acacia_planks.name=金合欢木
 
 #Remember to do the descriptions.
 
-#Obsidian Snakestone
-chisel.tile.obsidianSnakestone.name=黑曜蛇石
-
 #Iron Fence
-chisel.tile.fenceIron=铁栅栏
+tile.iron_bars.name=铁栅栏
 
 #Glass Panes
-chisel.tile.glassPane=玻璃板
+tile.glass_pane.name=玻璃板
 
 #Redstone block
-chisel.tile.blockRedstone.name=红石块
+tile.redstone_block.name=红石块
 
 #Holystone
-chisel.tile.blockHolystone.name=磨石
+tile.holystone.name=磨石
 
 #Lavastone
-chisel.tile.blockLavastone.name=熔岩石
+tile.lavastone.name=熔岩石
 
 #Carpet
-chisel.tile.blockCarpet.name=毯子
+tile.carpet_block.name=毯子
 
 #Carpet floor
-chisel.tile.blockCarpetFloor.name=地毯
+tile.carpet.name=地毯
 
 #Bookshelf
-chisel.tile.blockBookshelf.name=书架
+tile.bookshelf.name=书架
 
 #Tyrian
-chisel.tile.blockTyrian.name=提尔石砖
+tile.tyrian.name=提尔石砖
 
 #Temple
-chisel.tile.blockTemple.name=神庙石砖
+tile.templeblock.name=神庙石砖
 
 #Temple Mossy
-chisel.tile.blockTempleMossy.name=神庙苔石砖
+tile.mossy_templeblock.name=神庙苔石砖
 
 #Cloud
-chisel.tile.blockCloud.name=云朵
+tile.cloud.name=云朵
 
 #Stained glass T.T
-chisel.tile.chisel.stainedGlassWhite.name=染色玻璃
-chisel.tile.chisel.stainedGlassOrange.name=染色玻璃
-chisel.tile.chisel.stainedGlassMagenta.name=染色玻璃
-chisel.tile.chisel.stainedGlassLightBlue.name=染色玻璃
-chisel.tile.chisel.stainedGlassYellow.name=染色玻璃
-chisel.tile.chisel.stainedGlassLime.name=染色玻璃
-chisel.tile.chisel.stainedGlassPink.name=染色玻璃
-chisel.tile.chisel.stainedGlassGray.name=染色玻璃
-chisel.tile.chisel.stainedGlassLightGray.name=染色玻璃
-chisel.tile.chisel.stainedGlassCyan.name=染色玻璃
-chisel.tile.chisel.stainedGlassPurple.name=染色玻璃
-chisel.tile.chisel.stainedGlassBlue.name=染色玻璃
-chisel.tile.chisel.stainedGlassBrown.name=染色玻璃
-chisel.tile.chisel.stainedGlassGreen.name=染色玻璃
-chisel.tile.chisel.stainedGlassRed.name=染色玻璃
-chisel.tile.chisel.stainedGlassBlack.name=染色玻璃
+tile.stained_glass_white.name=染色玻璃
+tile.stained_glass_orange.name=染色玻璃
+tile.stained_glass_magenta.name=染色玻璃
+tile.stained_glass_lightBlue.name=染色玻璃
+tile.stained_glass_yellow.name=染色玻璃
+tile.stained_glass_lime.name=染色玻璃
+tile.stained_glass_pink.name=染色玻璃
+tile.stained_glass_gray.name=染色玻璃
+tile.stained_glass_lightgray.name=染色玻璃
+tile.stained_glass_cyan.name=染色玻璃
+tile.stained_glass_purple.name=染色玻璃
+tile.stained_glass_blue.name=染色玻璃
+tile.stained_glass_brown.name=染色玻璃
+tile.stained_glass_green.name=染色玻璃
+tile.stained_glass_red.name=染色玻璃
+tile.stained_glass_black.name=染色玻璃
 
 #Stained GlassPane T.T
-chisel.tile.chisel.stainedGlassPaneWhite.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneOrange.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneMagenta.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneLightBlue.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneYellow.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneLime.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPanePink.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneGray.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneLightGray.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneCyan.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPanePurple.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneBlue.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneBrown.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneGreen.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneRed.name=染色玻璃板
-chisel.tile.chisel.stainedGlassPaneBlack.name=染色玻璃板
-
-#Concerete
-chisel.tile.concrete.name=混凝土
+tile.stained_glass_pane_white.name=染色玻璃板
+tile.stained_glass_pane_orange.name=染色玻璃板
+tile.stained_glass_pane_magenta.name=染色玻璃板
+tile.stained_glass_pane_lightBlue.name=染色玻璃板
+tile.stained_glass_pane_yellow.name=染色玻璃板
+tile.stained_glass_pane_lime.name=染色玻璃板
+tile.stained_glass_pane_pink.name=染色玻璃板
+tile.stained_glass_pane_gray.name=染色玻璃板
+tile.stained_glass_pane_lightgray.name=染色玻璃板
+tile.stained_glass_pane_cyan.name=染色玻璃板
+tile.stained_glass_pane_purple.name=染色玻璃板
+tile.stained_glass_pane_blue.name=染色玻璃板
+tile.stained_glass_pane_brown.name=染色玻璃板
+tile.stained_glass_pane_green.name=染色玻璃板
+tile.stained_glass_pane_red.name=染色玻璃板
+tile.stained_glass_pane_black.name=染色玻璃板
 
 #Fantasy block
-chisel.tile.blockFft.name=幻想石砖
+tile.fantasyblock.name=幻想石砖
 
 #Paperwall
-chisel.tile.blockPaperwall.name=障子
+tile.paperwall.name=障子
 chisel.tile.paperwall.0.desc=方框障子
 chisel.tile.paperwall.1.desc=二等分障子
 chisel.tile.paperwall.2.desc=四等分障子
@@ -681,7 +675,7 @@ chisel.tile.paperwall.7.desc=空白障子
 chisel.tile.paperwall.8.desc=障子门
 
 #Woolen Clay
-chisel.tile.blockWoolenClay.name=羊毛粘土
+tile.woolen_clay.name=羊毛粘土
 chisel.tile.woolenClay.0.desc=白色羊毛粘土
 chisel.tile.woolenClay.1.desc=橙色色羊毛粘土
 chisel.tile.woolenClay.2.desc=品红色羊毛粘土
@@ -700,7 +694,7 @@ chisel.tile.woolenClay.14.desc=红色羊毛粘土
 chisel.tile.woolenClay.15.desc=黑色羊毛粘土
 
 #Laboratory Block
-chisel.tile.blockLaboratory.name=实验室方块
+tile.laboratoryblock.name=实验室方块
 chisel.tile.blockLaboratory.0.desc=墙板
 chisel.tile.blockLaboratory.1.desc=点状花纹墙板
 chisel.tile.blockLaboratory.2.desc=珐琅墙


### PR DESCRIPTION
I renamed all blocks according to the forge naming scheme and added a remapping file to guarantee compatibility.

This includes removal of all "chisel." and "chisel.chisel." blocks, "tile." block names and all the upper/lower-case names which should be renamed with "_". 

I tested the new localised names of all blocks and it looks fine.

This also closes #54 .
